### PR TITLE
Make resource names compatible with NVIDIA KubeVirt device plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ status:
   deviceId: "0d4c"
   classId: "0200"
   nodeName: "titan"
-  resourceName: "intel.com/EthernetConnection11I219LM"
+  resourceName: "intel.com/ETHERNET_CONNECTION_11_I219LM"
   description: "Ethernet controller: Intel Corporation Ethernet Connection (11) I219-LM"
   kernelDriverInUse: "e1000e"
 ```

--- a/charts/templates/crds.yaml
+++ b/charts/templates/crds.yaml
@@ -94,8 +94,8 @@ spec:
     - jsonPath: .spec.userName
       name: User Name
       type: string
-    - jsonPath: .status.kernelDriverInUse
-      name: Kernel Driver In Use
+    - jsonPath: .status.kernelDriverToUnbind
+      name: Kernel Driver Το Unbind
       type: string
     - jsonPath: .status.passthroughEnabled
       name: Passthrough Enabled
@@ -219,8 +219,8 @@ spec:
   - JSONPath: .spec.userName
     name: User Name
     type: string
-  - JSONPath: .status.kernelDriverInUse
-    name: Kernel Driver In Use
+  - JSONPath: .status.kernelDriverToUnbind
+    name: Kernel Driver Το Unbind
     type: string
   - JSONPath: .status.passthroughEnabled
     name: Passthrough Enabled

--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go
@@ -93,8 +93,15 @@ func resourceName(dev *pci.Device) string {
 	vendorCleaned := strings.ToLower(
 		strings.ReplaceAll(vendorBase, " ", ""),
 	) + ".com"
-	if dev.Product.Name != "" {
-		productCleaned := strings.ReplaceAll(strip(dev.Product.Name), " ", "")
+	if dev.Product.Name != util.UNKNOWN {
+		productCleaned := strings.TrimSpace(dev.Product.Name)
+		productCleaned = strings.ToUpper(productCleaned)
+		productCleaned = strings.Replace(productCleaned, "/", "_", -1)
+		productCleaned = strings.Replace(productCleaned, ".", "_", -1)
+		reg, _ := regexp.Compile("\\s+")
+		productCleaned = reg.ReplaceAllString(productCleaned, "_") // Replace all spaces with underscore
+		reg, _ = regexp.Compile("[^a-zA-Z0-9_.]+")
+		productCleaned = reg.ReplaceAllString(productCleaned, "") // Removes any char other than alphanumeric and underscore
 		return fmt.Sprintf("%s/%s", vendorCleaned, productCleaned)
 	}
 	// If the pcidb doesn't have the deviceId, just show the deviceId

--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
@@ -33,7 +33,11 @@ func TestNewPCIDeviceForName(t *testing.T) {
 						Name: "I350 Gigabit Network Connection",
 					},
 					Class: &pcidb.Class{
-						ID:   "0200",
+						ID:   "02",
+						Name: "Network controller",
+					},
+					Subclass: &pcidb.Subclass{
+						ID:   "00",
 						Name: "Ethernet controller",
 					},
 				},

--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
@@ -52,7 +52,7 @@ func TestNewPCIDeviceForName(t *testing.T) {
 					VendorId:     "8086",
 					DeviceId:     "1521",
 					ClassId:      "0200",
-					ResourceName: "intel.com/I350GigabitNetworkConnection",
+					ResourceName: "intel.com/I350_GIGABIT_NETWORK_CONNECTION",
 					Description:  "Ethernet controller: Intel Corporation I350 Gigabit Network Connection",
 					Address:      "00:1f.6",
 				},
@@ -93,7 +93,7 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 					},
 				},
 			},
-			want: "nvidia.com/GA100A100SXM440GB",
+			want: "nvidia.com/GA100_A100_SXM4_40GB",
 		},
 		{
 			name: "NVIDIA GeForce GTX 1060",
@@ -110,7 +110,7 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 					},
 				},
 			},
-			want: "nvidia.com/GP106GeForceGTX10603GB",
+			want: "nvidia.com/GP106_GEFORCE_GTX_1060_3GB",
 		},
 		{
 			name: "AMD Radeon X850",
@@ -127,7 +127,7 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 					},
 				},
 			},
-			want: "amd.com/R481RadeonX850XTAGP",
+			want: "amd.com/R481_RADEON_X850_XT_AGP",
 		},
 		{
 			name: "Intel I350 Gigabit Network Connection",
@@ -144,7 +144,7 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 					},
 				},
 			},
-			want: "intel.com/I350GigabitNetworkConnection",
+			want: "intel.com/I350_GIGABIT_NETWORK_CONNECTION",
 		},
 		{
 			name: "Mellanox MT2892",
@@ -161,7 +161,7 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 					},
 				},
 			},
-			want: "mellanox.com/MT2892FamilyConnectX6DxFlashRecovery",
+			want: "mellanox.com/MT2892_FAMILY_CONNECTX6_DX_FLASH_RECOVERY",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -92,7 +92,7 @@ func List() []crd.CRD {
 				WithColumn("Address", ".spec.address").
 				WithColumn("Node Name", ".spec.nodeName").
 				WithColumn("User Name", ".spec.userName").
-				WithColumn("Kernel Driver In Use", ".status.kernelDriverInUse").
+				WithColumn("Kernel Driver Το Unbind", ".status.kernelDriverToUnbind").
 				WithColumn("Passthrough Enabled", ".status.passthroughEnabled")
 		}),
 	}

--- a/sample/pcidevice.yaml
+++ b/sample/pcidevice.yaml
@@ -8,6 +8,6 @@ status:
   deviceId: "0d4c"
   classId: "0200"
   nodeName: "titan"
-  resourceName: "intel.com/intel.com/EthernetConnection11I219LM"
+  resourceName: "intel.com/ETHERNET_CONNECTION_11_I219LM"
   description: "Ethernet controller: Intel Corporation Ethernet Connection (11) I219-LM"
   kernelDriverInUse: "vfio-pci"


### PR DESCRIPTION
**- What I did**

* Used [this](https://github.com/NVIDIA/kubevirt-gpu-device-plugin/blob/v1.1.2/pkg/device_plugin/device_plugin.go#L317-L324) to clean device names

**- What I also did**

* Enabled PCI device subclass discovery (making descriptions more `lspci` friendly)
* Fixed `Kernel Driver Το Unbind` CRD column

**- How to verify it**

Unit tests are updated.