### PR TITLE
Fix permissions and name errors FIXES #2802

### DIFF
--- a/manifests/pcidevices-operator.yaml
+++ b/manifests/pcidevices-operator.yaml
@@ -11,7 +11,7 @@ rules:
     resources: [ "customresourcedefinitions" ]
     verbs: [ "*" ]
   - apiGroups: [ "" ]
-    resources: [ "nodes" ]
+    resources: [ "nodes", "secrets" ]
     verbs: [ "get", "watch", "list", "update" ]
   - apiGroups: [ "" ]
     resources: [ "configmaps", "events", "secrets"]
@@ -105,7 +105,7 @@ metadata:
   labels:
     app.kubernetes.io/name: pcidevices
     app.kubernetes.io/version: master-head
-  name: pcidevices
+  name: pcidevices-webhook
   namespace: harvester-system
 spec:
   ports:


### PR DESCRIPTION
I tested this on my 2 node cluster after installing the 1.1.0-rc1 (version 008b5d5)

This works, I verified that the PCI Devices create, that PCI Device Claims prepare the devices for passthrough.

Also I fixed a regression introduced in this PR: https://github.com/harvester/pcidevices/pull/12