### PR TITLE
After reboot, rebind pdc devices to vfio-pci FIXES #2819

### DIFF
--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -205,10 +205,6 @@ func (h Handler) reconcilePCIDeviceClaims(nodename string) error {
 					}
 					pdc.Status.PassthroughEnabled = true
 				}
-				_, err = h.pdcClient.Update(&pdc)
-				if err != nil {
-					return err
-				}
 				_, err = h.pdcClient.UpdateStatus(&pdc)
 				if err != nil {
 					return err


### PR DESCRIPTION
Fix #2819 by looking at all PCIDeviceClaims whose underlying devices are not currently bound to vfio-pci. This usually happens after a node reboot.

# Other small changes
- hostname switched to more accurate "nodename"

# Testing
I created 6 PCIDeviceClaims, all 6 underlying devices were correctly bound to `vfio-pci`, and then rebooted. Those six devices were not bound to `vfio-pci` anymore. I added logic into the reconciliation loop that unbound the PCI Devices belonging to the claims, and then bound them to `vfio-pci`. I verified that it worked on my 6 underlying devices. 