### PR TITLE
Handle the todos

### DIFF
--- a/pkg/controller/pcidevice/pcidevice_controller.go
+++ b/pkg/controller/pcidevice/pcidevice_controller.go
@@ -61,7 +61,6 @@ func (h Handler) reconcilePCIDevices(nodename string) error {
 		var devCR *v1beta1.PCIDevice
 		devCR, err = h.client.Get(name, metav1.GetOptions{})
 
-		// TODO use k8s.io/apimachinery/apierrors IsNotFound
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				logrus.Infof("[PCIDeviceController] Device %s does not exist", name)

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
@@ -1,0 +1,104 @@
+package pcideviceclaim
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHandler_getOrphanedPCIDevices(t *testing.T) {
+	type args struct {
+		nodename string
+		pdcs     *v1beta1.PCIDeviceClaimList
+		pds      *v1beta1.PCIDeviceList
+	}
+	orphanpd := v1beta1.PCIDevice{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "testnode1-00003f062",
+			UID:  "450a6607-b836-46fe-9ced-c23cb2cfdef0",
+		},
+		Status: v1beta1.PCIDeviceStatus{
+			Address:           "0000:3f:06.2",
+			KernelDriverInUse: "vfio-pci",
+			NodeName:          "testnode1",
+		},
+	}
+	pd := v1beta1.PCIDevice{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "testnode1-00003f063",
+		},
+		Status: v1beta1.PCIDeviceStatus{
+			Address:           "0000:3f:06.3",
+			KernelDriverInUse: "vfio-pci",
+			NodeName:          "testnode1",
+		},
+	}
+	pdc := v1beta1.PCIDeviceClaim{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "testnode1-00003f063",
+			OwnerReferences: []v1.OwnerReference{
+				v1.OwnerReference{
+					Kind: "PCIDevice",
+					Name: "testnode1-00003f063",
+					UID:  pd.GetObjectMeta().GetUID(),
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *v1beta1.PCIDeviceList
+		wantErr bool
+	}{
+		{
+			name: "One PCIDevice bound to vfio-pci and zero PCIDeviceClaims",
+			args: args{
+				nodename: "testnode1",
+				pdcs:     &v1beta1.PCIDeviceClaimList{},
+				pds: &v1beta1.PCIDeviceList{
+					Items: []v1beta1.PCIDevice{orphanpd}},
+			},
+			want:    &v1beta1.PCIDeviceList{Items: []v1beta1.PCIDevice{orphanpd}},
+			wantErr: false,
+		},
+		{
+			name: "Two PCIDevices bound to vfio-pci and one PCIDeviceClaim",
+			args: args{
+				nodename: "testnode1",
+				pdcs: &v1beta1.PCIDeviceClaimList{
+					Items: []v1beta1.PCIDeviceClaim{
+						pdc,
+					},
+				},
+				pds: &v1beta1.PCIDeviceList{
+					Items: []v1beta1.PCIDevice{
+						orphanpd, // this should be returned
+						pd,       // this should not be returned, since it's claimed above
+					},
+				},
+			},
+			want: &v1beta1.PCIDeviceList{
+				Items: []v1beta1.PCIDevice{
+					orphanpd,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getOrphanedPCIDevices(tt.args.nodename, tt.args.pdcs, tt.args.pds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Handler.getOrphanedPCIDevices() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Handler.getOrphanedPCIDevices() = %v, \nwant %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Check if the device is currently bound to the driver in the unbind function
- Extract the getOrphanedPCIDevices function and add unit tests
- Unbind all the orphaned devices to ensure only claimed devices are bound to vfio-pci