### PR TITLE
Retry rebind after reboot if error happens

### DIFF
--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -3,6 +3,9 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/rancher/wrangler/pkg/yaml"
 	"github.com/stretchr/testify/require"
@@ -14,8 +17,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"strings"
-	"testing"
 )
 
 const (
@@ -279,4 +280,5 @@ func Test_createCapabilitiesPatch(t *testing.T) {
 	err = json.Unmarshal(newPodJson, newPod)
 	assert.NoError(err, "no error found during conversion of json to pod")
 	assert.Len(newPod.Spec.Containers[0].SecurityContext.Capabilities.Add, 3, "expected to find 3 capabilities")
+	assert.Equal(newPod.Spec.Containers[0].SecurityContext.Capabilities.Add[2], corev1.Capability("SYS_RESOURCE"))
 }


### PR DESCRIPTION
- Based on feedback from PR #23
- Returning the error from rebindAfterReboot will cause the call to Register to return an error, which will crash the Pod. This is desired behavior, because we want to retry the rebindAfterReboot before doing anything else.