### PR TITLE
Call update on KubeVirt to trigger allow-list update

### DIFF
--- a/manifests/pcidevices-operator.yaml
+++ b/manifests/pcidevices-operator.yaml
@@ -31,6 +31,9 @@ rules:
   - apiGroups: ["kubevirt.io"]
     resources: ["kubevirts"]
     verbs: [ "get", "update" ]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines"]
+    verbs: [ "get", "list", "watch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -233,11 +233,12 @@ func (h Handler) addHostDeviceToKubeVirt(pd *v1beta1.PCIDevice) error {
 			ExternalResourceProvider: false,
 		}
 		kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices = append(permittedPCIDevices, devToPermit)
-		_, err := h.virtClient.KubeVirt(DefaultNS).Update(kvCopy)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to update kubevirt CR: %s", err)
-			return errors.New(msg)
-		}
+	}
+	// update KubeVirt CR anyway to trigger a nodes.status.allocatable update
+	_, err = h.virtClient.KubeVirt(DefaultNS).Update(kvCopy)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to update kubevirt CR: %s", err)
+		return errors.New(msg)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes:
- [2991](https://github.com/harvester/harvester/issues/2991) Can't remove or reassign a PCI device
- [2820](https://github.com/harvester/harvester/issues/2820) Making a PCI Device Claim doesn't allow-list the device in KubeVirt


How I tested this:
- I built `tlehman/pcidevices:dev`, built a new chart and deployed it to my cluster. I confirmed that the KubeVirt allow list stayed up to date when I enabled and disabled my two GPUs. Also I attached a GeForce 1660 to ubuntu-gpu1, installed the driver, then I removed the 1660 and attached it to suse-gpu1 and booted it up. The bug 2991 is caused by the same problem in 2820
