### PR TITLE
Add Node Cleanup Controller [FIXES #3224]

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func run(kubeConfig string) error {
 			logrus.Fatalf("failed to make new client: %s", err)
 		}
 		go leader.RunOrDie(ctx, "harvester-system", "pcidevices-node-cleanup", clientSet, func(cb context.Context) {
-			if err := nodecleanup.Register(ctx, nodeName, pdcCtl, pdCtl, nodeCtl); err != nil {
+			if err := nodecleanup.Register(ctx, pdcCtl, pdCtl, nodeCtl); err != nil {
 				logrus.Fatalf("failed to register Node Cleanup Controller")
 			}
 		})

--- a/pkg/controller/nodecleanup/nodecleanup_controller.go
+++ b/pkg/controller/nodecleanup/nodecleanup_controller.go
@@ -12,7 +12,6 @@ import (
 )
 
 type Handler struct {
-	nodeName   string
 	pdcClient  v1beta1.PCIDeviceClaimClient
 	pdClient   v1beta1.PCIDeviceClient
 	nodeClient corecontrollers.NodeController
@@ -29,7 +28,7 @@ func (h *Handler) OnRemove(_ string, node *v1.Node) (*v1.Node, error) {
 		return node, err
 	}
 	for _, pdc := range pdcs.Items {
-		if pdc.Spec.NodeName != h.nodeName {
+		if pdc.Spec.NodeName != node.Name {
 			continue
 		}
 		err = h.pdcClient.Delete(pdc.Name, &metav1.DeleteOptions{})
@@ -58,12 +57,10 @@ func (h *Handler) OnRemove(_ string, node *v1.Node) (*v1.Node, error) {
 
 func Register(
 	ctx context.Context,
-	nodeName string,
 	pdcClient v1beta1.PCIDeviceClaimController,
 	pdClient v1beta1.PCIDeviceController,
 	nodeClient corecontrollers.NodeController) error {
 	handler := &Handler{
-		nodeName:   nodeName,
 		pdcClient:  pdcClient,
 		pdClient:   pdClient,
 		nodeClient: nodeClient,

--- a/pkg/controller/nodecleanup/nodecleanup_controller.go
+++ b/pkg/controller/nodecleanup/nodecleanup_controller.go
@@ -1,0 +1,73 @@
+package nodecleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/harvester/pcidevices/pkg/generated/controllers/devices.harvesterhci.io/v1beta1"
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Handler struct {
+	nodeName   string
+	pdcClient  v1beta1.PCIDeviceClaimClient
+	pdClient   v1beta1.PCIDeviceClient
+	nodeClient corecontrollers.NodeController
+}
+
+func (h *Handler) OnRemove(_ string, node *v1.Node) (*v1.Node, error) {
+	if node == nil || node.DeletionTimestamp == nil {
+		return node, nil
+	}
+	// Delete all of that Node's PCIDeviceClaims
+	pdcs, err := h.pdcClient.List(metav1.ListOptions{})
+	if err != nil {
+		logrus.Errorf("error getting pdcs: %s", err)
+		return node, err
+	}
+	for _, pdc := range pdcs.Items {
+		if pdc.Spec.NodeName != h.nodeName {
+			continue
+		}
+		err = h.pdcClient.Delete(pdc.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Errorf("error deleting pdc: %s", err)
+			return node, err
+		}
+	}
+	// Delete all of that Node's PCIDevices
+	selector := fmt.Sprintf("nodename=%s", node.Name)
+	pds, err := h.pdClient.List(metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		logrus.Errorf("error getting pds: %s", err)
+		return node, err
+	}
+	for _, pd := range pds.Items {
+		err = h.pdClient.Delete(pd.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Errorf("error deleting pd: %s", err)
+			return node, err
+		}
+	}
+
+	return node, nil
+}
+
+func Register(
+	ctx context.Context,
+	nodeName string,
+	pdcClient v1beta1.PCIDeviceClaimController,
+	pdClient v1beta1.PCIDeviceController,
+	nodeClient corecontrollers.NodeController) error {
+	handler := &Handler{
+		nodeName:   nodeName,
+		pdcClient:  pdcClient,
+		pdClient:   pdClient,
+		nodeClient: nodeClient,
+	}
+	nodeClient.OnRemove(ctx, "node-remove", handler.OnRemove)
+	return nil
+}

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -48,9 +48,9 @@ func Register(
 	ctx context.Context,
 	pdcClient v1beta1gen.PCIDeviceClaimController,
 	pdClient v1beta1gen.PCIDeviceController,
+	nodeName string,
 ) error {
 	logrus.Info("Registering PCI Device Claims controller")
-	nodename := os.Getenv("NODE_NAME")
 	clientConfig := kubecli.DefaultClientConfig(&pflag.FlagSet{})
 	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(clientConfig)
 	if err != nil {
@@ -61,7 +61,7 @@ func Register(
 	handler := &Handler{
 		pdcClient:     pdcClient,
 		pdClient:      pdClient,
-		nodeName:      nodename,
+		nodeName:      nodeName,
 		virtClient:    virtClient,
 		devicePlugins: make(map[string]*deviceplugins.PCIDevicePlugin),
 	}

--- a/tests/integration/node_test.go
+++ b/tests/integration/node_test.go
@@ -1,0 +1,201 @@
+package integration
+
+import (
+	"fmt"
+	"time"
+
+	devicesv1beta1 "github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("run node deletion tests", func() {
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+	}
+
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			DeletionTimestamp: &metav1.Time{
+				Time: time.Now(),
+			},
+		},
+	}
+
+	claim1Node1 := &devicesv1beta1.PCIDeviceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "dev1node1",
+			Finalizers: []string{"wrangler.cattle.io/PCIDeviceClaimOnRemove"},
+		},
+		Spec: devicesv1beta1.PCIDeviceClaimSpec{
+			NodeName: "node1",
+		},
+	}
+
+	claim2Node1 := &devicesv1beta1.PCIDeviceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "dev2node1",
+			Finalizers: []string{"wrangler.cattle.io/PCIDeviceClaimOnRemove"},
+		},
+		Spec: devicesv1beta1.PCIDeviceClaimSpec{
+			NodeName: "node1",
+		},
+	}
+
+	claim1Node2 := &devicesv1beta1.PCIDeviceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dev1node2",
+			//Finalizers: []string{"wrangler.cattle.io/PCIDeviceClaimOnRemove"},
+		},
+		Spec: devicesv1beta1.PCIDeviceClaimSpec{
+			NodeName: "node2",
+		},
+	}
+
+	claim2Node2 := &devicesv1beta1.PCIDeviceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dev2node2",
+			//Finalizers: []string{"wrangler.cattle.io/PCIDeviceClaimOnRemove"},
+		},
+		Spec: devicesv1beta1.PCIDeviceClaimSpec{
+			NodeName: "node2",
+		},
+	}
+
+	dev1Node1 := &devicesv1beta1.PCIDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dev1node1",
+			Labels: map[string]string{
+				"nodename": "node1",
+			},
+		},
+	}
+
+	dev2Node1 := &devicesv1beta1.PCIDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dev2node1",
+			Labels: map[string]string{
+				"nodename": "node1",
+			},
+		},
+	}
+
+	dev1Node2 := &devicesv1beta1.PCIDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dev1node2",
+			Labels: map[string]string{
+				"nodename": "node2",
+			},
+		},
+	}
+
+	dev2Node2 := &devicesv1beta1.PCIDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dev2node2",
+			Labels: map[string]string{
+				"nodename": "node2",
+			},
+		},
+	}
+	BeforeEach(func() {
+		Eventually(func() error {
+			return k8sClient.Create(ctx, node1)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, node2)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, dev1Node1)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, dev2Node1)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, dev1Node2)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, dev2Node2)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, claim1Node1)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, claim2Node1)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, claim1Node2)
+		}).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Create(ctx, claim2Node2)
+		}).ShouldNot(HaveOccurred())
+	})
+
+	It("delete node2 and reconcile devices", func() {
+		By("deleting node2", func() {
+			Eventually(func() error {
+				return k8sClient.Delete(ctx, node2)
+			}).ShouldNot(HaveOccurred())
+		})
+
+		By("query node2", func() {
+			Eventually(func() error {
+				nodeObj := &corev1.Node{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: node2.Name, Namespace: node2.Namespace}, nodeObj)
+
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+
+				return err
+			}).ShouldNot(HaveOccurred())
+		})
+
+		By("reconcile node2 pcidevices", func() {
+			Eventually(func() error {
+				devList := &devicesv1beta1.PCIDeviceList{}
+
+				selector := labels.SelectorFromSet(map[string]string{
+					"nodename": node2.Name,
+				})
+
+				if err := k8sClient.List(ctx, devList, &client.ListOptions{LabelSelector: selector}); err != nil {
+					return err
+				}
+
+				if len(devList.Items) != 0 {
+					return fmt.Errorf("expected to find no pcidevices for node2")
+				}
+				return nil
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
+		By("reconcile node2 pcideviceclaims", func() {
+			Eventually(func() error {
+				claimList := &devicesv1beta1.PCIDeviceClaimList{}
+				if err := k8sClient.List(ctx, claimList); err != nil {
+					return err
+				}
+
+				GinkgoWriter.Println(claimList.Items)
+				for _, v := range claimList.Items {
+					if v.Spec.NodeName == node2.Name {
+						return fmt.Errorf("found pcidevice claim for node2")
+					}
+				}
+				return nil
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
+	})
+
+})


### PR DESCRIPTION
- Adds nodecleanup controller to register the node OnRemove event
- Uses leader election to only cleanup the objects on the leader node
- TODO: needs RBAC changes in harvester/charts to use the coordination.k8s.io resources