### PR TITLE
Create IOMMU siblings of PCIDeviceClaims #3451

### DIFF
--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go
@@ -42,6 +42,10 @@ type PCIDeviceStatus struct {
 	KernelDriverInUse string `json:"kernelDriverInUse,omitempty"`
 }
 
+func (p *PCIDevice) String() string {
+	return fmt.Sprintf("PCIDevice{name: \"%s\", ...}", p.ObjectMeta.Name)
+}
+
 func description(dev *pci.Device) string {
 	var vendorName string
 	if dev.Vendor.Name != util.UNKNOWN {

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
@@ -103,3 +103,92 @@ func TestHandler_getOrphanedPCIDevices(t *testing.T) {
 		})
 	}
 }
+
+// IOMMU Groups need to be kept together on the same VM
+func Test_getIommuSiblings(t *testing.T) {
+	type args struct {
+		pd  *v1beta1.PCIDevice
+		pds []*v1beta1.PCIDevice // other devices (includes all siblings)
+	}
+
+	// Goal of this test: make PCIDeviceClaims for both devices in
+	// IOMMU group 14, but not in 23
+	iommuGroupMap := map[string]int{
+		"0000:04:00.0": 14,
+		"0000:04:00.1": 14,
+		"0000:24:00.3": 23,
+	}
+
+	// All PCIDevices on the same node as the given device
+	pds := []*v1beta1.PCIDevice{
+		&v1beta1.PCIDevice{ // GPU
+			ObjectMeta: v1.ObjectMeta{
+				Name: "janus-000004000",
+			},
+			Status: v1beta1.PCIDeviceStatus{
+				Address:      "0000:04:00.0",
+				ClassId:      "0300",
+				Description:  "VGA compatible controller: NVIDIA Corporation GP106 [GeForce GTX 1060 3GB]",
+				DeviceId:     "1c02",
+				IOMMUGroup:   "14",
+				NodeName:     "janus",
+				ResourceName: "nvidia.com/GP106_GEFORCE_GTX_1060_3GB",
+				VendorId:     "10de",
+			},
+		},
+		&v1beta1.PCIDevice{ // GPU's Audio Device (same IOMMU group)
+			ObjectMeta: v1.ObjectMeta{
+				Name: "janus-000004001",
+			},
+			Status: v1beta1.PCIDeviceStatus{
+				Address:           "0000:04:00.1",
+				ClassId:           "0403",
+				Description:       "Audio device: NVIDIA Corporation GP106 High Definition Audio Controller",
+				DeviceId:          "10f1",
+				IOMMUGroup:        "14",
+				KernelDriverInUse: "snd_hda_intel",
+				NodeName:          "janus",
+				ResourceName:      "nvidia.com/GP106_HIGH_DEFINITION_AUDIO_CONTROLLER",
+				VendorId:          "10de",
+			},
+		},
+		&v1beta1.PCIDevice{ // device in different IOMMU Group
+			ObjectMeta: v1.ObjectMeta{
+				Name: "janus-000024003",
+			},
+			Status: v1beta1.PCIDeviceStatus{
+				Address:      "0000:24:00.3",
+				ClassId:      "0C80",
+				Description:  "Class 0C80: NVIDIA Corporation TU116 USB Type-C UCSI Controller",
+				DeviceId:     "1aed",
+				IOMMUGroup:   "23",
+				NodeName:     "janus",
+				ResourceName: "nvidia.com/TU116_USB_TYPEC_UCSI_CONTROLLER",
+				VendorId:     "10de",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []*v1beta1.PCIDevice
+	}{
+		{
+			name: "nvidia card with audio device",
+			args: args{
+				pd:  pds[0],
+				pds: pds,
+			},
+			want: pds[:2], // only the first two, which are in IOMMU group 14
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getIommuSiblings(tt.args.pd, tt.args.pds, iommuGroupMap); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getIommuSiblings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
When I create a PCIDeviceClaim, if there are "siblings" in the IOMMU group, then this PCIDeviceClaim alone cannot be attached to a VM.

**Solution:**
Change the reconcile loop in the PCIDeviceClaims controller to look up and create the IOMMU siblings so that all of the  IOMMU group's members will be claimed.

**Related Issue:**
- https://github.com/harvester/harvester/issues/3451

**Test plan:**
- Find a device whose IOMMU group has more than 1 device in it. 
- Claim one of the devices in the group, 
- Verify that the other members of the group (siblings) are claimed 