### PR TITLE
Security upgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,18 +13,18 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
 	github.com/rancher/dynamiclistener v0.3.5
-	github.com/rancher/lasso v0.0.0-20220628160937-749b3397db38
-	github.com/rancher/wrangler v1.0.2
+	github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc
+	github.com/rancher/wrangler v1.1.0
 	github.com/sirupsen/logrus v1.9.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	github.com/u-root/u-root v7.0.0+incompatible
 	github.com/urfave/cli/v2 v2.11.1
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	google.golang.org/grpc v1.48.0
-	k8s.io/api v0.24.7
-	k8s.io/apimachinery v0.24.7
+	k8s.io/api v0.25.4
+	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/kube-aggregator v0.24.0
+	k8s.io/kube-aggregator v0.25.4
 	kubevirt.io/client-go v0.54.0
 	kubevirt.io/kubevirt v0.54.0
 	sigs.k8s.io/controller-runtime v0.12.3
@@ -109,8 +109,8 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.24.3 // indirect
-	k8s.io/code-generator v0.24.3 // indirect
+	k8s.io/apiextensions-apiserver v0.25.4 // indirect
+	k8s.io/code-generator v0.25.4 // indirect
 	k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20221004154528-8021a29435af
+	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.0.0-20220808172628-8227340efae7 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-aggregator v0.25.4
 	kubevirt.io/client-go v0.54.0
-	kubevirt.io/kubevirt v0.54.0
+	kubevirt.io/kubevirt v0.55.1
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1347,8 +1347,8 @@ kubevirt.io/containerized-data-importer-api v1.47.0 h1:fncmQ/2J8MVb3c2snNkUXlBQX
 kubevirt.io/containerized-data-importer-api v1.47.0/go.mod h1:yjD8pGZVMCeqcN46JPUQdZ2JwRVoRCOXrTVyNuFvrLo=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
-kubevirt.io/kubevirt v0.54.0 h1:BKs0j+/ep4xGWcis3uIQzRZbFXuTy8ttUsX/r9mFBIE=
-kubevirt.io/kubevirt v0.54.0/go.mod h1:5bTNJ+dZcfUiCV9QToT38sK6R5VW+oiTqb4YSwCVi0g=
+kubevirt.io/kubevirt v0.55.1 h1:9Ls8Z+gohnQ4fVAHycfhdU1sqsjcaFROjMUZJucOEh0=
+kubevirt.io/kubevirt v0.55.1/go.mod h1:qyX4+kdsnXkqmSMYM+e6cW+huKGpFFX6bXzVflH2uV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -694,10 +694,10 @@ github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rancher/dynamiclistener v0.3.5 h1:5TaIHvkDGmZKvc96Huur16zfTKOiLhDtK4S+WV0JA6A=
 github.com/rancher/dynamiclistener v0.3.5/go.mod h1:dW/YF6/m2+uEyJ5VtEcd9THxda599HP6N9dSXk81+k0=
-github.com/rancher/lasso v0.0.0-20220628160937-749b3397db38 h1:RcYCbUUb7ln5UtvBKjG8Kjyh30pwqlxf+fJnVsdUIwU=
-github.com/rancher/lasso v0.0.0-20220628160937-749b3397db38/go.mod h1:sMLCrn5NBypoWCc7wf9pNdzXOZ+HBlO0RHIppPmLOCA=
-github.com/rancher/wrangler v1.0.2 h1:0JGv62gF2OkYUoR0fsr99Za63fquFeKTHE2z9kAFVsE=
-github.com/rancher/wrangler v1.0.2/go.mod h1:Blhan9LdaIJjC9w+xGteSrHHEiIFIdPEHEMrtx82dPk=
+github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc h1:29VHrInLV4qSevvcvhBj5UhQWkPShxrxv4AahYg2Scw=
+github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
+github.com/rancher/wrangler v1.1.0 h1:1VWistON261oKmCPF5fOPMWb/YwjgEciO9pCw5Z0mzQ=
+github.com/rancher/wrangler v1.1.0/go.mod h1:lQorqAAIMkNWteece1GiuwZTmMqkaVTXL5qjiiPVDxQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -761,6 +761,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -768,8 +769,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
**Problem:**
Upgrading vulnerable packages based on the security scan done in https://github.com/harvester/security/issues/19

**Solution:**
- **github.com/rancher/wrangler** 1.0.1 -> 1.1.0
- **kubevirt.io/kubevirt** -> 55.1
- **golang.org/x/net** -> 0.7.0 (highest version covered all three CVEs)
- For **github.com/u-root/u-root**, I verified that the fix was is 0.11.0, but when I attempt to upgrade to 0.11.0, the `go mod tidy` step downgrades kubevirt to 0.17.4. Since we are only using u-root/pkg/kmodule, in [one place](https://github.com/tlehman/pcidevices/blob/master/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go#L130), none of the three CVEs flagged for this version apply to our usage of the library, so it is safe for us to leave it alone for now.
  - [[CVE-2020-7665](https://nvd.nist.gov/vuln/detail/CVE-2020-7665)](https://nvd.nist.gov/vuln/detail/CVE-2020-7665) pkg/uzip **path traversal attack**                                                                                             
  - [[CVE-2020-7666](https://nvd.nist.gov/vuln/detail/CVE-2020-7666)](https://nvd.nist.gov/vuln/detail/CVE-2020-7666) pkg/cpio **path traversal and symlink attacks**
  - [[CVE-2020-7669](https://nvd.nist.gov/vuln/detail/CVE-2020-7669)](https://nvd.nist.gov/vuln/detail/CVE-2020-7669) pkg/tarutil **path traversal and symlink attacks**
    - https://github.com/u-root/u-root/pull/1817 "zipslip"
(Notice how pkg/kmodule is not implicated, also these vulnerabilities are only exploitable with a malicious, user-crafted path input. We use a hard-coded path in a non-affected package, so these vulnerabilities can be safely dismissed in our case).

**Related Issue:**
https://github.com/harvester/security/issues/19

**Test plan:**
Make sure none of the 1.1.2 functionality related to PCI devices is broken by this
