### PR TITLE
Fixes for iommu grouping and pcidevice claim bind/unbind

### DIFF
--- a/pkg/webhook/vm.go
+++ b/pkg/webhook/vm.go
@@ -172,12 +172,9 @@ func generateDevicePatch(dev *devicesv1beta1.PCIDevice) (types.PatchOps, error) 
 
 func identifyAdditionalPCIDevices(pciDevicesInVM []string, possiblePCIDeviceRequirement []pciDeviceWithOwners) []pciDeviceWithOwners {
 	var additionalDevicesNeeded []pciDeviceWithOwners
-	for _, currentDevice := range pciDevicesInVM {
-		for _, additionalDev := range possiblePCIDeviceRequirement {
-			if currentDevice == additionalDev.device.Name {
-				continue
-			}
-			additionalDevicesNeeded = append(additionalDevicesNeeded, additionalDev)
+	for _, v := range possiblePCIDeviceRequirement {
+		if !additionalDeviceAlreadyExists(pciDevicesInVM, v.device.Name) {
+			additionalDevicesNeeded = append(additionalDevicesNeeded, v)
 		}
 	}
 	return additionalDevicesNeeded
@@ -218,4 +215,14 @@ func generatePCIDeviceClaim(dev *devicesv1beta1.PCIDevice, owner string) *device
 			UserName: owner,
 		},
 	}
+}
+
+func additionalDeviceAlreadyExists(devList []string, dev string) bool {
+	for _, v := range devList {
+		if v == dev {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR addresses two issues:
* bind/unbind reports device busy. This is likely due to lack of leader election logic, where node X may process a PCIDeviceClaim for node Y. In this scenario it will just ignore object, and wrangler ends up removing the finalizer. however the actual unbinding/binding may not have been performed. requeuing such objects allows us to ensure device is rebound to correct driver. additional checks have been added to ensure that device is correct bound and available in driver tree before operation is reconcilled successfully.
* in cases where all pcidevices of an iommu group are already present in a VM, no additional devices should be added. there was a bug where we were not checking if other devices from iommu group are already in the VM definition, resulting in devices being duplicated in the patch generated by mutating webhook. this has been correct as well. related issue: https://github.com/harvester/harvester/issues/3631
* 
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
