### PR TITLE
change how network links are looked up without hostNetwork

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -22,6 +22,7 @@ ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/harvester/pcidevices/
 ENV DAPPER_OUTPUT ./bin ./dist ./pkg
 ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_RUN_ARGS "-v /proc:/host/proc --privileged"
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/manifests/pcidevices-operator.yaml
+++ b/manifests/pcidevices-operator.yaml
@@ -100,6 +100,8 @@ spec:
               name: sys
             - mountPath: /var/lib/kubelet/device-plugins
               name: device-plugins
+            - mountPath: /host/proc
+              name: proc
       priorityClassName: system-node-critical
       serviceAccountName: pcidevices
       volumes:
@@ -115,6 +117,10 @@ spec:
             path: /sys
             type: Directory
           name: sys
+        - hostPath:
+            path: /proc
+            type: Directory
+          name: proc
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/util/nichelper/helper.go
+++ b/pkg/util/nichelper/helper.go
@@ -20,6 +20,46 @@ const (
 )
 
 func IdentifyHarvesterManagedNIC(nodeName string, nodeCache ctlcorev1.NodeCache, vlanConfigCache ctlnetworkv1beta1.VlanConfigCache) ([]string, error) {
+	var skipInterfaces []string
+	managementInterfaces, err := IdentifyManagementNics()
+	if err != nil {
+		return nil, err
+	}
+
+	skipInterfaces = append(skipInterfaces, managementInterfaces...)
+
+	// query interfaces used for vlanConfigs and add them to list of skipped interfaces
+	vlanConfigNICS, err := identifyClusterNetworks(nodeName, nodeCache, vlanConfigCache)
+	if err != nil {
+		return nil, err
+	}
+
+	skipInterfaces = append(skipInterfaces, vlanConfigNICS...)
+
+	logrus.Debugf("skipping interfaces %v", skipInterfaces)
+
+	// pciAddressess contains the pci addresses for the management nics
+	var pciAddresses []string
+	nics, err := ghw.Network()
+	if err != nil {
+		return nil, fmt.Errorf("error listing network info: %v", err)
+	}
+
+	for _, v := range skipInterfaces {
+		for _, nic := range nics.NICs {
+			if nic.Name == v {
+				pciAddresses = append(pciAddresses, *nic.PCIAddress)
+			}
+		}
+	}
+
+	logrus.Debugf("skipping interfaces with pciAddresses: %v", pciAddresses)
+	return pciAddresses, nil
+}
+
+// IdentifyManagementNics will identify the NICS used on the host for default harvester management
+// and bonded interfaces
+func IdentifyManagementNics() ([]string, error) {
 	hostProcessNS, err := netns.GetFromPath("/host/proc/1/ns/net")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching host network namespace: %v", err)
@@ -60,33 +100,7 @@ func IdentifyHarvesterManagedNIC(nodeName string, nodeCache ctlcorev1.NodeCache,
 		}
 	}
 
-	// query interfaces used for vlanConfigs and add them to list of skipped interfaces
-	vlanConfigNICS, err := identifyClusterNetworks(nodeName, nodeCache, vlanConfigCache)
-	if err != nil {
-		return nil, err
-	}
-
-	skipInterfaces = append(skipInterfaces, vlanConfigNICS...)
-
-	logrus.Debugf("skipping interfaces %v", skipInterfaces)
-
-	// pciAddressess contains the pci addresses for the management nics
-	var pciAddresses []string
-	nics, err := ghw.Network()
-	if err != nil {
-		return nil, fmt.Errorf("error listing network info: %v", err)
-	}
-
-	for _, v := range skipInterfaces {
-		for _, nic := range nics.NICs {
-			if nic.Name == v {
-				pciAddresses = append(pciAddresses, *nic.PCIAddress)
-			}
-		}
-	}
-
-	logrus.Debugf("skipping interfaces with pciAddresses: %v", pciAddresses)
-	return pciAddresses, nil
+	return skipInterfaces, nil
 }
 
 // identifyClusterNetworks will identify vlanConfigs covering the current node and identify NICs in use for


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR changes how netlink library is used to access the host network namespace, without use of hostNetwork.

As a result of this change, the mutating webhook pod is no longer exposed on the host network.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
