### PR TITLE
fix for upgrade path for kubevirt permitted host devices

### DIFF
--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
@@ -142,16 +142,15 @@ var (
 
 func Test_permitHostDeviceInKubevirtWithNoDevices(t *testing.T) {
 	assert := require.New(t)
-	reconcileKubevirtCR(kubevirtCR, pd)
-	assert.Len(kubevirtCR.Spec.Configuration.PermittedHostDevices.PciHostDevices, 1, "expected to find one device added")
+	kvCopy := reconcileKubevirtCR(kubevirtCR, pd)
+	assert.Len(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices, 1, "expected to find one device added")
 }
 
 func Test_permitHostDeviceInKubevirtWithoutExternalResourceDevices(t *testing.T) {
 	assert := require.New(t)
 	kubevirtCR.Spec.Configuration.PermittedHostDevices = permittedHostDevices
-	kvCopy := kubevirtCR.DeepCopy()
-	reconcileKubevirtCR(kvCopy, pd)
-	assert.False(reflect.DeepEqual(kvCopy, kubevirtCR), "expected to find changes in the kubevirt CR")
+	kvCopy := reconcileKubevirtCR(kubevirtCR, pd)
+	assert.False(reflect.DeepEqual(kvCopy.Spec.Configuration.PermittedHostDevices, kubevirtCR.Spec.Configuration.PermittedHostDevices), "expected to find changes in the kubevirt CR")
 	assert.Len(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices, 1, "expected to find one device added")
 	assert.True(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices[0].ExternalResourceProvider, "expected external resource provider to be updated")
 }
@@ -160,9 +159,8 @@ func Test_permitHostDeviceInKubevirtWithExternalResourceDevices(t *testing.T) {
 	assert := require.New(t)
 	permittedHostDevices.PciHostDevices[0].ExternalResourceProvider = true
 	kubevirtCR.Spec.Configuration.PermittedHostDevices = permittedHostDevices
-	kvCopy := kubevirtCR.DeepCopy()
-	reconcileKubevirtCR(kvCopy, pd)
-	assert.True(reflect.DeepEqual(kvCopy, kubevirtCR), "expected to find no changes in the kubevirt CR")
+	kvCopy := reconcileKubevirtCR(kubevirtCR, pd)
+	assert.True(reflect.DeepEqual(kvCopy.Spec.Configuration.PermittedHostDevices, kubevirtCR.Spec.Configuration.PermittedHostDevices), "expected to find no changes in the kubevirt CR")
 	assert.Len(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices, 1, "expected to find one device added")
 	assert.True(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices[0].ExternalResourceProvider, "expected external resource provider to be updated")
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Related to: https://github.com/harvester/harvester/issues/3763

PR introduces a simple fix to ensure that `externalResourceProvider` is set for existing PCIDeviceClaims, to ensure that kubevirt can offload the management of the same to the device plugin introduced in newer versions.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
