### PR TITLE
fine tune resourceName in PCIDevice object if needed

### DIFF
--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
@@ -1,11 +1,13 @@
 package v1beta1
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/jaypipes/ghw/pkg/pci"
 	"github.com/jaypipes/pcidb"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -179,5 +181,45 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 				t.Errorf("\ndescription() = %v,\nwant %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_trimResourceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		vendorCleaned  string
+		productCleaned string
+		ID             string
+		want           string
+	}{
+		{
+			name:           "long virtual function name",
+			vendorCleaned:  "broadcom.com",
+			productCleaned: "NETXTREME_II_BCM57810_10_GIGABIT_ETHERNET_VIRTUAL_FUNCTION",
+			ID:             "16af",
+			want:           "broadcom.com/NETXTREME_II_BCM57810_10_GIGABIT_ETHERNET_VF",
+		},
+		{
+
+			name:           "shorter product name",
+			vendorCleaned:  "broadcom.com",
+			productCleaned: "NETXTREME_II_BCM57810_10_GIGABIT_ETHERNET",
+			ID:             "16af",
+			want:           "broadcom.com/NETXTREME_II_BCM57810_10_GIGABIT_ETHERNET",
+		},
+		{
+
+			name:           "long product name",
+			vendorCleaned:  "broadcom.com",
+			productCleaned: "NETXTREME_II_BCM57810_10_GIGABIT_ETHERNET_REALLY_REALLY_LONG_NAME",
+			ID:             "16af",
+			want:           "broadcom.com/16af",
+		},
+	}
+
+	assert := require.New(t)
+	for _, tt := range tests {
+		resourceName := trimResourceNameIfNeeded(tt.vendorCleaned, tt.productCleaned, tt.ID)
+		assert.Equal(tt.want, resourceName, fmt.Sprintf("expected resourceName did not match specified for case: %s", tt.name))
 	}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In cases where `ResourceName` is really long, usually in case of Virtual Functions, the device plugin socket file name can easily exceed 108 char limit. This causes issue with initialization of device plugin.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a minor fix to perform the following change, where additional changes are performed if device plugin socket file name is going to exceed 108 characters.

* If 108 limit is exceeded, and resource name contains `VIRTUAL_FUNCTION`, then attempt to replace `VIRTUAL_FUNCTION` with `VF`
* If resource name is still longer than 108 chars then replace resourceName with `Device ID`

**Related Issue:**
https://github.com/harvester/harvester/issues/4806

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
