### PR TITLE
feat: bump golangci-lint to v1.55.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,9 +15,7 @@ RUN export K8S_VERSION=1.24.2 && \
     tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
 
 ## install golangci
-RUN if [ "${ARCH}" = "amd64" ]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0; \
-    fi
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
 
 ENV GO111MODULE on
 ENV DAPPER_ENV REPO TAG DRONE_TAG

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -97,7 +97,7 @@ func Register(
 }
 
 // When a PCIDeviceClaim is removed, we need to unbind the device from the vfio-pci driver
-func (h *Handler) OnRemove(name string, pdc *v1beta1.PCIDeviceClaim) (*v1beta1.PCIDeviceClaim, error) {
+func (h *Handler) OnRemove(_ string, pdc *v1beta1.PCIDeviceClaim) (*v1beta1.PCIDeviceClaim, error) {
 	if pdc == nil || pdc.DeletionTimestamp == nil {
 		return pdc, nil
 	}
@@ -276,7 +276,7 @@ func getOrphanedPCIDevices(
 	return &pdsOrphaned, nil
 }
 
-func (h *Handler) reconcilePCIDeviceClaims(name string, pdc *v1beta1.PCIDeviceClaim) (*v1beta1.PCIDeviceClaim, error) {
+func (h *Handler) reconcilePCIDeviceClaims(_ string, pdc *v1beta1.PCIDeviceClaim) (*v1beta1.PCIDeviceClaim, error) {
 
 	if pdc == nil || pdc.DeletionTimestamp != nil || (pdc.Spec.NodeName != h.nodeName) {
 		return pdc, nil

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -25,7 +25,7 @@ import (
 	"github.com/harvester/pcidevices/pkg/webhook"
 )
 
-func Setup(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme) error {
+func Setup(ctx context.Context, cfg *rest.Config, _ *runtime.Scheme) error {
 	err := crd.Create(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("error setting up crds: %v", err)

--- a/pkg/deviceplugins/deviceplugin.go
+++ b/pkg/deviceplugins/deviceplugin.go
@@ -9,7 +9,7 @@ import (
 	"github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
 )
 
-func (dp *PCIDevicePlugin) MarkPCIDeviceAsHealthy(resourceName string, pciAddress string) {
+func (dp *PCIDevicePlugin) MarkPCIDeviceAsHealthy(_ string, pciAddress string) {
 	go func() {
 		dp.health <- deviceHealth{
 			DevID:  pciAddress,

--- a/pkg/util/fakeclients/node.go
+++ b/pkg/util/fakeclients/node.go
@@ -33,11 +33,11 @@ func (c NodeCache) List(selector labels.Selector) ([]*v1.Node, error) {
 	return result, err
 }
 
-func (c NodeCache) AddIndexer(indexName string, indexer ctlcorev1.NodeIndexer) {
+func (c NodeCache) AddIndexer(_ string, _ ctlcorev1.NodeIndexer) {
 	panic("implement me")
 }
 
-func (c NodeCache) GetByIndex(indexName, key string) ([]*v1.Node, error) {
+func (c NodeCache) GetByIndex(_, _ string) ([]*v1.Node, error) {
 	panic("implement me")
 }
 
@@ -48,18 +48,18 @@ func (c NodeClient) Update(node *v1.Node) (*v1.Node, error) {
 }
 
 func (c NodeClient) Get(name string, options metav1.GetOptions) (*v1.Node, error) {
-	return c().Get(context.TODO(), name, metav1.GetOptions{})
+	return c().Get(context.TODO(), name, options)
 }
 
 func (c NodeClient) Create(node *v1.Node) (*v1.Node, error) {
 	return c().Create(context.TODO(), node, metav1.CreateOptions{})
 }
 
-func (c NodeClient) Delete(name string, options *metav1.DeleteOptions) error {
+func (c NodeClient) Delete(_ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c NodeClient) List(opts metav1.ListOptions) (*v1.NodeList, error) {
+func (c NodeClient) List(metav1.ListOptions) (*v1.NodeList, error) {
 	panic("implement me")
 }
 
@@ -67,10 +67,10 @@ func (c NodeClient) UpdateStatus(*v1.Node) (*v1.Node, error) {
 	panic("implement me")
 }
 
-func (c NodeClient) Watch(pts metav1.ListOptions) (watch.Interface, error) {
+func (c NodeClient) Watch(metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c NodeClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Node, err error) {
+func (c NodeClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *v1.Node, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/pcidevices.go
+++ b/pkg/util/fakeclients/pcidevices.go
@@ -25,7 +25,7 @@ func (p PCIDevicesClient) Update(d *pcidevicev1beta1.PCIDevice) (*pcidevicev1bet
 }
 
 func (p PCIDevicesClient) Get(name string, options metav1.GetOptions) (*pcidevicev1beta1.PCIDevice, error) {
-	return p().Get(context.TODO(), name, metav1.GetOptions{})
+	return p().Get(context.TODO(), name, options)
 }
 
 func (p PCIDevicesClient) Create(d *pcidevicev1beta1.PCIDevice) (*pcidevicev1beta1.PCIDevice, error) {
@@ -40,11 +40,11 @@ func (p PCIDevicesClient) List(opts metav1.ListOptions) (*pcidevicev1beta1.PCIDe
 	return p().List(context.TODO(), opts)
 }
 
-func (p PCIDevicesClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (p PCIDevicesClient) Watch(metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (p PCIDevicesClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *pcidevicev1beta1.PCIDevice, err error) {
+func (p PCIDevicesClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *pcidevicev1beta1.PCIDevice, err error) {
 	panic("implement me")
 }
 
@@ -58,11 +58,11 @@ func (p PCIDevicesCache) Get(name string) (*pcidevicev1beta1.PCIDevice, error) {
 	return p().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (p PCIDevicesCache) List(selector labels.Selector) ([]*pcidevicev1beta1.PCIDevice, error) {
+func (p PCIDevicesCache) List(labels.Selector) ([]*pcidevicev1beta1.PCIDevice, error) {
 	panic("implement me")
 }
 
-func (p PCIDevicesCache) AddIndexer(indexName string, indexer pcidevicesv1beta1ctl.PCIDeviceIndexer) {
+func (p PCIDevicesCache) AddIndexer(_ string, _ pcidevicesv1beta1ctl.PCIDeviceIndexer) {
 	panic("implement me")
 }
 

--- a/pkg/util/fakeclients/pcidevicesclaim.go
+++ b/pkg/util/fakeclients/pcidevicesclaim.go
@@ -20,7 +20,7 @@ func (p PCIDeviceClaimsClient) Update(d *pcidevicev1beta1.PCIDeviceClaim) (*pcid
 }
 
 func (p PCIDeviceClaimsClient) Get(name string, options metav1.GetOptions) (*pcidevicev1beta1.PCIDeviceClaim, error) {
-	return p().Get(context.TODO(), name, metav1.GetOptions{})
+	return p().Get(context.TODO(), name, options)
 }
 
 func (p PCIDeviceClaimsClient) Create(d *pcidevicev1beta1.PCIDeviceClaim) (*pcidevicev1beta1.PCIDeviceClaim, error) {
@@ -35,11 +35,11 @@ func (p PCIDeviceClaimsClient) List(opts metav1.ListOptions) (*pcidevicev1beta1.
 	return p().List(context.TODO(), opts)
 }
 
-func (p PCIDeviceClaimsClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (p PCIDeviceClaimsClient) Watch(metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (p PCIDeviceClaimsClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *pcidevicev1beta1.PCIDeviceClaim, err error) {
+func (p PCIDeviceClaimsClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *pcidevicev1beta1.PCIDeviceClaim, err error) {
 	panic("implement me")
 }
 
@@ -53,14 +53,14 @@ func (p PCIDeviceClaimsCache) Get(name string) (*pcidevicev1beta1.PCIDeviceClaim
 	return p().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (p PCIDeviceClaimsCache) List(selector labels.Selector) ([]*pcidevicev1beta1.PCIDeviceClaim, error) {
+func (p PCIDeviceClaimsCache) List(labels.Selector) ([]*pcidevicev1beta1.PCIDeviceClaim, error) {
 	panic("implement me")
 }
 
-func (p PCIDeviceClaimsCache) AddIndexer(indexName string, indexer pcidevicesv1beta1ctl.PCIDeviceClaimIndexer) {
+func (p PCIDeviceClaimsCache) AddIndexer(_ string, _ pcidevicesv1beta1ctl.PCIDeviceClaimIndexer) {
 	panic("implement me")
 }
 
-func (p PCIDeviceClaimsCache) GetByIndex(indexName, key string) ([]*pcidevicev1beta1.PCIDeviceClaim, error) {
+func (p PCIDeviceClaimsCache) GetByIndex(_, _ string) ([]*pcidevicev1beta1.PCIDeviceClaim, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/sriovdevices.go
+++ b/pkg/util/fakeclients/sriovdevices.go
@@ -21,7 +21,7 @@ func (s SriovDevicesClient) Update(d *pcidevicev1beta1.SRIOVNetworkDevice) (*pci
 }
 
 func (s SriovDevicesClient) Get(name string, options metav1.GetOptions) (*pcidevicev1beta1.SRIOVNetworkDevice, error) {
-	return s().Get(context.TODO(), name, metav1.GetOptions{})
+	return s().Get(context.TODO(), name, options)
 }
 
 func (s SriovDevicesClient) Create(d *pcidevicev1beta1.SRIOVNetworkDevice) (*pcidevicev1beta1.SRIOVNetworkDevice, error) {
@@ -36,11 +36,11 @@ func (s SriovDevicesClient) List(opts metav1.ListOptions) (*pcidevicev1beta1.SRI
 	return s().List(context.TODO(), opts)
 }
 
-func (s SriovDevicesClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (s SriovDevicesClient) Watch(metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (s SriovDevicesClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *pcidevicev1beta1.SRIOVNetworkDevice, err error) {
+func (s SriovDevicesClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (*pcidevicev1beta1.SRIOVNetworkDevice, error) {
 	panic("implement me")
 }
 
@@ -69,7 +69,7 @@ func (s SriovDevicesCache) List(selector labels.Selector) ([]*pcidevicev1beta1.S
 	return result, err
 }
 
-func (s SriovDevicesCache) AddIndexer(indexName string, indexer pcidevicesv1beta1ctl.SRIOVNetworkDeviceIndexer) {
+func (s SriovDevicesCache) AddIndexer(_ string, _ pcidevicesv1beta1ctl.SRIOVNetworkDeviceIndexer) {
 	panic("implement me")
 }
 

--- a/pkg/util/fakeclients/vlanconfig.go
+++ b/pkg/util/fakeclients/vlanconfig.go
@@ -31,10 +31,10 @@ func (c VlanConfigCache) List(selector labels.Selector) ([]*v1beta1.VlanConfig, 
 	return result, err
 }
 
-func (c VlanConfigCache) AddIndexer(indexName string, indexer ctlnetworkv1beta1.VlanConfigIndexer) {
+func (c VlanConfigCache) AddIndexer(_ string, _ ctlnetworkv1beta1.VlanConfigIndexer) {
 	panic("implement me")
 }
 
-func (c VlanConfigCache) GetByIndex(indexName, key string) ([]*v1beta1.VlanConfig, error) {
+func (c VlanConfigCache) GetByIndex(_, _ string) ([]*v1beta1.VlanConfig, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/vm.go
+++ b/pkg/util/fakeclients/vm.go
@@ -23,18 +23,18 @@ func (c VirtualMachineClient) Update(virtualMachine *kubevirtv1api.VirtualMachin
 }
 
 func (c VirtualMachineClient) Get(namespace, name string, options metav1.GetOptions) (*kubevirtv1api.VirtualMachine, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 
 func (c VirtualMachineClient) Create(virtualMachine *kubevirtv1api.VirtualMachine) (*kubevirtv1api.VirtualMachine, error) {
 	return c(virtualMachine.Namespace).Create(context.TODO(), virtualMachine, metav1.CreateOptions{})
 }
 
-func (c VirtualMachineClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c VirtualMachineClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) List(namespace string, opts metav1.ListOptions) (*kubevirtv1api.VirtualMachineList, error) {
+func (c VirtualMachineClient) List(_ string, _ metav1.ListOptions) (*kubevirtv1api.VirtualMachineList, error) {
 	panic("implement me")
 }
 
@@ -42,11 +42,11 @@ func (c VirtualMachineClient) UpdateStatus(*kubevirtv1api.VirtualMachine) (*kube
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c VirtualMachineClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *kubevirtv1api.VirtualMachine, err error) {
+func (c VirtualMachineClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *kubevirtv1api.VirtualMachine, err error) {
 	panic("implement me")
 }
 
@@ -71,7 +71,7 @@ func (c VirtualMachineCache) List(namespace string, selector labels.Selector) ([
 	return result, err
 }
 
-func (c VirtualMachineCache) AddIndexer(indexName string, indexer kubevirtctlv1.VirtualMachineIndexer) {
+func (c VirtualMachineCache) AddIndexer(_ string, _ kubevirtctlv1.VirtualMachineIndexer) {
 	panic("implement me")
 }
 

--- a/pkg/util/nichelper/helper.go
+++ b/pkg/util/nichelper/helper.go
@@ -130,7 +130,7 @@ func IdentifyManagementNics() ([]string, error) {
 
 // identifyClusterNetworks will identify vlanConfigs covering the current node and identify NICs in use for
 // vlanconfigs
-func identifyClusterNetworks(nodeName string, nodeCache ctlcorev1.NodeCache, vlanConfigCache ctlnetworkv1beta1.VlanConfigCache) ([]string, error) {
+func identifyClusterNetworks(nodeName string, _ ctlcorev1.NodeCache, vlanConfigCache ctlnetworkv1beta1.VlanConfigCache) ([]string, error) {
 	var nicsList []string
 	vlanConfigList, err := vlanConfigCache.List(labels.NewSelector())
 	if err != nil {

--- a/pkg/webhook/pcideviceclaim.go
+++ b/pkg/webhook/pcideviceclaim.go
@@ -40,7 +40,7 @@ func (pdc *pciDeviceClaimValidator) Resource() types.Resource {
 	}
 }
 
-func (pdc *pciDeviceClaimValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (pdc *pciDeviceClaimValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	pciClaimObj := newObj.(*devicesv1beta1.PCIDeviceClaim)
 	pciDev, err := pdc.deviceCache.Get(pciClaimObj.Name)
 	if err != nil {
@@ -55,7 +55,7 @@ func (pdc *pciDeviceClaimValidator) Create(request *types.Request, newObj runtim
 	return nil
 }
 
-func (pdc *pciDeviceClaimValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (pdc *pciDeviceClaimValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	pciClaimObj := oldObj.(*devicesv1beta1.PCIDeviceClaim)
 	vms, err := pdc.kubevirtCache.GetByIndex(VMByPCIDeviceClaim, pciClaimObj.Name)
 	if err != nil {

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -57,7 +57,7 @@ func (m *podMutator) Resource() types.Resource {
 	})
 }
 
-func (m *podMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (m *podMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	pod := newObj.(*corev1.Pod)
 
 	podLabels := labels.Set(pod.Labels)

--- a/pkg/webhook/sriov.go
+++ b/pkg/webhook/sriov.go
@@ -39,7 +39,7 @@ func (s *sriovNetworkDeviceValidator) Resource() types.Resource {
 	}
 }
 
-func (s *sriovNetworkDeviceValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (s *sriovNetworkDeviceValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldSriovDevice := oldObj.(*devicesv1beta1.SRIOVNetworkDevice)
 	newSriovDevice := newObj.(*devicesv1beta1.SRIOVNetworkDevice)
 
@@ -54,7 +54,7 @@ func (s *sriovNetworkDeviceValidator) Update(request *types.Request, oldObj runt
 	return nil
 }
 
-func (s *sriovNetworkDeviceValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (s *sriovNetworkDeviceValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	oldSriovDevice := oldObj.(*devicesv1beta1.SRIOVNetworkDevice)
 	return s.checkVFInUse(oldSriovDevice)
 

--- a/pkg/webhook/vm.go
+++ b/pkg/webhook/vm.go
@@ -60,7 +60,7 @@ func (vm *vmPCIMutator) Resource() types.Resource {
 	}
 }
 
-func (vm *vmPCIMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (vm *vmPCIMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	vmObj := newObj.(*kubevirtv1.VirtualMachine)
 
 	if len(vmObj.Spec.Template.Spec.Domain.Devices.HostDevices) == 0 {
@@ -70,7 +70,7 @@ func (vm *vmPCIMutator) Create(request *types.Request, newObj runtime.Object) (t
 	return vm.generatePatch(vmObj)
 }
 
-func (vm *vmPCIMutator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
+func (vm *vmPCIMutator) Update(_ *types.Request, _ runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
 	vmObj := newObj.(*kubevirtv1.VirtualMachine)
 	oldVMObj := newObj.(*kubevirtv1.VirtualMachine)
 

--- a/tests/integration/mutator_test.go
+++ b/tests/integration/mutator_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/integration/node_test.go
+++ b/tests/integration/node_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	"github.com/rancher/wrangler/pkg/generic"
@@ -46,6 +46,27 @@ var (
 		},
 	}
 )
+
+// Declarations for Ginkgo DSL
+var Fail = ginkgo.Fail
+var Describe = ginkgo.Describe
+var It = ginkgo.It
+var By = ginkgo.By
+var BeforeEach = ginkgo.BeforeEach
+var AfterEach = ginkgo.AfterEach
+var BeforeSuite = ginkgo.BeforeSuite
+var AfterSuite = ginkgo.AfterSuite
+var RunSpecs = ginkgo.RunSpecs
+var GinkgoWriter = ginkgo.GinkgoWriter
+
+// Declarations for Gomega Matchers
+var RegisterFailHandler = gomega.RegisterFailHandler
+var Equal = gomega.Equal
+var Expect = gomega.Expect
+var BeNil = gomega.BeNil
+var HaveOccurred = gomega.HaveOccurred
+var BeEmpty = gomega.BeEmpty
+var Eventually = gomega.Eventually
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
**Problem:**
The golangci-lint version before v1.51.0 may have OOM issue with golang v1.20.

**Solution:**
Bump golangci-lint to a version after v1.51.0.

**Related Issue:**
https://github.com/harvester/harvester/issues/4938
