### PR TITLE
change logic to filter MIG GPUs

### DIFF
--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	defaultTotalVFFile      = "sriov_totalvfs"
 	defaultConfiguredVFFile = "sriov_numvfs"
+	defaultVFCheckFile      = "sriov_vf_device"
 )
 
-// IsDeviceSRIOVCapable checks for existence of `sriov_totalvfs` file in the pcidevice tree
+// IsDeviceSRIOVCapable checks for existence of `sriov_vf_device` file in the pcidevice tree
 func IsDeviceSRIOVCapable(devicePath string) (bool, error) {
-	_, err := os.Stat(filepath.Join(devicePath, defaultTotalVFFile))
+	vfCheckFilePath := filepath.Join(devicePath, defaultVFCheckFile)
+	_, err := os.Stat(vfCheckFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -23,6 +24,14 @@ func IsDeviceSRIOVCapable(devicePath string) (bool, error) {
 		return false, err
 	}
 
+	contents, err := os.ReadFile(vfCheckFilePath)
+	if err != nil {
+		return false, err
+	}
+
+	if strings.TrimSuffix(string(contents), "\n") == "0" {
+		return false, nil
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
NVIDIA GPU's supporting MIG mode vGPU's are also detected as SRIOVGPUDevices.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces logic to filter out NVIDIA GPU's which support MIG mode vGPU's only.

Currently these GPU's also have a sriov_totalvfs file as a result of which the devices show up as `SRIOVGPUDevices`.

The check has been changed to check `sriov_vf_device` file which contains the vf device ID. 

On MIG devices this contains `0` while on GPU's supporting vGPU's this contains a hexadecimal device id.

**Related Issue:**
https://github.com/harvester/harvester/issues/5112
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
