### PR TITLE
Fixing pcidevice device plugin stop deadlock

### DIFF
--- a/pkg/controller/nodes/node_controller.go
+++ b/pkg/controller/nodes/node_controller.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/harvester/pcidevices/pkg/controller/gpudevice"
-
 	ctlnetworkv1beta1 "github.com/harvester/harvester-network-controller/pkg/generated/controllers/network.harvesterhci.io/v1beta1"
 	"github.com/jaypipes/ghw"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
@@ -17,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
+	"github.com/harvester/pcidevices/pkg/controller/gpudevice"
 	"github.com/harvester/pcidevices/pkg/controller/pcidevice"
 	"github.com/harvester/pcidevices/pkg/controller/sriovdevice"
 	ctl "github.com/harvester/pcidevices/pkg/generated/controllers/devices.harvesterhci.io/v1beta1"

--- a/pkg/deviceplugins/deviceplugin.go
+++ b/pkg/deviceplugins/deviceplugin.go
@@ -92,5 +92,11 @@ func (dp *PCIDevicePlugin) RemoveDevice(pd *v1beta1.PCIDevice, pdc *v1beta1.PCID
 		logrus.Infof("Removing %s from device plugin", resourceName)
 		dp.MarkPCIDeviceAsUnhealthy(pdc.Spec.Address)
 	}
+
+	for i, dev := range dp.devs {
+		if dev.ID == pdc.Spec.Address {
+			dp.devs[i].Health = pluginapi.Unhealthy
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
**Problem:**
pci controller stops the device plugin with potential deadlock

**Solution:**
Refactor the device plugin stop flow to terminate it gracefully, the flow would like this:
- Device plugin [close chan dp.done](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L398-L400) and [wait the notification from chan dp.deregistered](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L406)
- `healthCheck()\performCheck()` is [kicked by chan dp.done and gets out of the loop](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L359-L360)
- `ListAndWatch()` is [kicked by chan dp.done and gets out of the loop](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L239-L240)
- `ListAndWatch()` [sends an empty list response and closes chan dp.deregistered](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L250-L253)
- `stopDevicePlugin()` is [notified by chan dp.deregistered](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L406) and [stops the server gracefully](https://github.com/harvester/pcidevices/blob/a42eb589df13728a1e91a374d6734a70aedf3d8f/pkg/deviceplugins/device_manager.go#L410-L412)

**Related Issue:**
https://github.com/harvester/harvester/issues/5164

**Test Plan:**
- Enable and disable one pcidevice passthrough
- There should be not error message similar as `device plugin failed to deregister: rpc error: code = Unavaila  
│ ble desc = transport is closing","pos":"device_manager.go:250","reason":"rpc error: code = Unavailable desc = transport is closing"` in the pci controller daemonset
