### PR TITLE
Pci device plugin fix orphan goroutine and remove unused channel

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,10 +9,8 @@ RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.6/hardw
 RUN go install golang.org/x/lint/golint@latest
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN go install github.com/incu6us/goimports-reviser/v3@v3.10.0
-RUN export K8S_VERSION=1.24.2 && \
-    curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)" && \
-    mkdir /usr/local/kubebuilder && \
-    tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
+    setup-envtest use 1.31.x --bin-dir /usr/local/kubebuilder -p path
 
 ## install golangci
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest

--- a/pkg/controller/gpudevice/vgpu_controller.go
+++ b/pkg/controller/gpudevice/vgpu_controller.go
@@ -8,14 +8,12 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 
 	"github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
 	"github.com/harvester/pcidevices/pkg/deviceplugins"

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -491,17 +491,14 @@ func (h *Handler) startDevicePlugin(
 	if dp.Started() {
 		return nil
 	}
-	// Start the plugin
-	stop := make(chan struct{})
+
 	go func() {
-		err := dp.Start(stop)
+		err := dp.Start()
 		if err != nil {
 			logrus.Errorf("error starting %s device plugin: %s", dp.GetDeviceName(), err)
 		}
-		// TODO: test if deleting this stops the DevicePlugin
-		<-stop
 	}()
-	dp.SetStarted(stop)
+	dp.SetStarted()
 	return nil
 }
 


### PR DESCRIPTION
**Problem:**
After a PCI device plugin is disabled, there is Go routine (invoked as the device plugin started) [blocked by chan stop](https://github.com/harvester/pcidevices/blob/82535bf09278420d225eaf3fe8dbff2e450b8f71/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go#L429-L436), however, chan stop is never touched, this brings an orphan Go routine once a PCI device is enabled and disabled.

**Solution:**
PCI device plugin fix the orphan goroutine and removes unused channel

**Related Issue:**
https://github.com/harvester/harvester/issues/5179

**Additional Context:**
The CodeFactor `Complex Method` error could be fixed once PR https://github.com/harvester/pcidevices/pull/66 merged