### PR TITLE
change pod mutation webhook logic for kubevirt v1.1.x support

### DIFF
--- a/tests/integration/mutator_test.go
+++ b/tests/integration/mutator_test.go
@@ -92,7 +92,7 @@ var _ = Describe("validate mutator by sending a mock pod request needing mutatio
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "fakepod",
+					Name:  "compute",
 					Image: "fakeimage",
 					SecurityContext: &corev1.SecurityContext{
 						Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PCIDevice passthrough is currently broken in v1.2-head due to upgrade to kubevirt v1.1.x

This is due to the change in launcher pod now running two containers rather than the original one in v0.55.x

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR manually backports the changes to pod mutation in webhook from master branch. This has already been fixed in v1.3.0

**Related Issue:**
https://github.com/harvester/harvester/issues/5373
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
