### PR TITLE
convert sriov device name objects to lowercase

### DIFF
--- a/pkg/util/nichelper/helper.go
+++ b/pkg/util/nichelper/helper.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
-	ctlnetworkv1beta1 "github.com/harvester/harvester-network-controller/pkg/generated/controllers/network.harvesterhci.io/v1beta1"
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/net"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
@@ -17,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/json"
+
+	ctlnetworkv1beta1 "github.com/harvester/harvester-network-controller/pkg/generated/controllers/network.harvesterhci.io/v1beta1"
 
 	"github.com/harvester/pcidevices/pkg/util/common"
 
@@ -271,7 +273,7 @@ func generateSRIOVDeviceObjects(nodeName string, nics *net.Info, skipNics []stri
 func generateSRIOVDev(nodeName string, nic *net.NIC) *v1beta1.SRIOVNetworkDevice {
 	return &v1beta1.SRIOVNetworkDevice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", nodeName, nic.Name),
+			Name: strings.ToLower(fmt.Sprintf("%s-%s", nodeName, nic.Name)),
 			Labels: map[string]string{
 				v1beta1.NodeKeyName: nodeName,
 			},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In certain cases nic names may have uppercase characters. This can cause failures in the pcidevices controller when it attempts to setup the sriov network devices.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The fix is to convert sriov network device names to lowercase.

**Related Issue:**
https://github.com/harvester/harvester/issues/6502
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
