### PR TITLE
feat: remove orphaned USB device automatically and add reconcile after deleting claim

### DIFF
--- a/pkg/apis/devices.harvesterhci.io/v1beta1/usb_device.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/usb_device.go
@@ -14,6 +14,8 @@ type USBDevice struct {
 	Status USBDeviceStatus `json:"status,omitempty"`
 }
 
+const USBDeviceStatusOrphaned = "orphaned"
+
 type USBDeviceStatus struct {
 	VendorID     string `json:"vendorID"`
 	ProductID    string `json:"productID"`
@@ -23,4 +25,6 @@ type USBDeviceStatus struct {
 	Description  string `json:"description"`
 	PCIAddress   string `json:"pciAddress"`
 	Enabled      bool   `json:"enabled"`
+	Status       string `json:"status,omitempty"`
+	Message      string `json:"message,omitempty"`
 }

--- a/pkg/controller/usbdevice/register.go
+++ b/pkg/controller/usbdevice/register.go
@@ -16,14 +16,12 @@ const (
 )
 
 func Register(ctx context.Context, management *config.FactoryManager) error {
-	reconcileUSBDevice := make(chan struct{}, 1)
-
 	usbDeviceCtrl := management.DeviceFactory.Devices().V1beta1().USBDevice()
 	usbDeviceClaimCtrl := management.DeviceFactory.Devices().V1beta1().USBDeviceClaim()
 	virtClient := management.KubevirtFactory.Kubevirt().V1().KubeVirt()
 
 	handler := NewHandler(usbDeviceCtrl, usbDeviceClaimCtrl, usbDeviceCtrl.Cache(), usbDeviceClaimCtrl.Cache())
-	usbDeviceClaimController := NewClaimHandler(usbDeviceCtrl.Cache(), usbDeviceClaimCtrl, usbDeviceCtrl, virtClient, reconcileUSBDevice)
+	usbDeviceClaimController := NewClaimHandler(usbDeviceCtrl.Cache(), usbDeviceClaimCtrl, usbDeviceCtrl, virtClient, handler.reconcileSignal)
 
 	// Initial reconcile
 	if err := handler.reconcile(); err != nil {
@@ -31,7 +29,7 @@ func Register(ctx context.Context, management *config.FactoryManager) error {
 		return err
 	}
 
-	if err := handler.WatchUSBDevices(ctx, reconcileUSBDevice); err != nil {
+	if err := handler.WatchUSBDevices(ctx); err != nil {
 		logrus.Errorf("error watching usb devices: %v", err)
 		return err
 	}

--- a/pkg/controller/usbdevice/usbdevice_claim_controller.go
+++ b/pkg/controller/usbdevice/usbdevice_claim_controller.go
@@ -98,27 +98,23 @@ func (h *DevClaimHandler) OnUSBDeviceClaimChanged(_ string, usbDeviceClaim *v1be
 		devicePlugin = usbDevicePlugin
 	}
 
+	usbDeviceCp := usbDevice.DeepCopy()
+
 	if !devicePlugin.IsStarted() {
 		devicePlugin.StartDevicePlugin()
 
-		usbDeviceCp := usbDevice.DeepCopy()
 		// Reset status and message regardless of the original status when the device plugin is started
 		usbDeviceCp.Status.Status = ""
 		usbDeviceCp.Status.Message = ""
-
-		if !reflect.DeepEqual(usbDevice.Status, usbDeviceCp.Status) {
-			if usbDevice, err = h.usbClient.UpdateStatus(usbDeviceCp); err != nil {
-				logrus.Errorf("failed to enable usb device %s status: %v", usbDeviceCp.Name, err)
-				return usbDeviceClaim, err
-			}
-		}
 	}
 
 	if !usbDevice.Status.Enabled {
-		usbDeviceCp := usbDevice.DeepCopy()
 		usbDeviceCp.Status.Enabled = true
-		if _, err = h.usbClient.UpdateStatus(usbDeviceCp); err != nil {
-			logrus.Errorf("failed to enable usb device %s status: %v", usbDeviceCp.Name, err)
+	}
+
+	if !reflect.DeepEqual(usbDevice.Status, usbDeviceCp.Status) {
+		if usbDevice, err = h.usbClient.UpdateStatus(usbDeviceCp); err != nil {
+			logrus.Errorf("failed to update usb device %s status: %v", usbDeviceCp.Name, err)
 			return usbDeviceClaim, err
 		}
 	}

--- a/pkg/controller/usbdevice/usbdevice_claim_controller_test.go
+++ b/pkg/controller/usbdevice/usbdevice_claim_controller_test.go
@@ -67,12 +67,7 @@ func Test_OnUSBDeviceClaimChanged(t *testing.T) {
 		{
 			fun: func(t *testing.T) {
 				client := fake.NewSimpleClientset(mockUsbDevice1, mockUsbDeviceClaim1, mockKubeVirt)
-				handler := NewClaimHandler(
-					fakeclients.USBDeviceCache(client.DevicesV1beta1().USBDevices),
-					fakeclients.USBDeviceClaimsClient(client.DevicesV1beta1().USBDeviceClaims),
-					fakeclients.USBDevicesClient(client.DevicesV1beta1().USBDevices),
-					fakeclients.KubeVirtClient(client.KubevirtV1().KubeVirts),
-				)
+				handler := NewClaimHandler(fakeclients.USBDeviceCache(client.DevicesV1beta1().USBDevices), fakeclients.USBDeviceClaimsClient(client.DevicesV1beta1().USBDeviceClaims), fakeclients.USBDevicesClient(client.DevicesV1beta1().USBDevices), fakeclients.KubeVirtClient(client.KubevirtV1().KubeVirts), make(chan struct{}))
 
 				// Test claim created
 				_, err := handler.OnUSBDeviceClaimChanged("", mockUsbDeviceClaim1)
@@ -123,12 +118,7 @@ func Test_OnUSBDeviceClaimChanged(t *testing.T) {
 		{
 			fun: func(_ *testing.T) {
 				client := fake.NewSimpleClientset(mockUsbDevice1, mockUsbDeviceClaim1, mockKubeVirt)
-				handler := NewClaimHandler(
-					fakeclients.USBDeviceCache(client.DevicesV1beta1().USBDevices),
-					fakeclients.USBDeviceClaimsClient(client.DevicesV1beta1().USBDeviceClaims),
-					fakeclients.USBDevicesClient(client.DevicesV1beta1().USBDevices),
-					fakeclients.KubeVirtClient(client.KubevirtV1().KubeVirts),
-				)
+				handler := NewClaimHandler(fakeclients.USBDeviceCache(client.DevicesV1beta1().USBDevices), fakeclients.USBDeviceClaimsClient(client.DevicesV1beta1().USBDeviceClaims), fakeclients.USBDevicesClient(client.DevicesV1beta1().USBDevices), fakeclients.KubeVirtClient(client.KubevirtV1().KubeVirts), make(chan struct{}))
 
 				// Test claim created
 				_, err := handler.OnUSBDeviceClaimChanged("", mockUsbDeviceClaim1)
@@ -141,12 +131,7 @@ func Test_OnUSBDeviceClaimChanged(t *testing.T) {
 		{
 			fun: func(_ *testing.T) {
 				client := fake.NewSimpleClientset(mockUsbDevice1, mockUsbDeviceClaim1, mockKubeVirt)
-				handler := NewClaimHandler(
-					fakeclients.USBDeviceCache(client.DevicesV1beta1().USBDevices),
-					fakeclients.USBDeviceClaimsClient(client.DevicesV1beta1().USBDeviceClaims),
-					fakeclients.USBDevicesClient(client.DevicesV1beta1().USBDevices),
-					fakeclients.KubeVirtClient(client.KubevirtV1().KubeVirts),
-				)
+				handler := NewClaimHandler(fakeclients.USBDeviceCache(client.DevicesV1beta1().USBDevices), fakeclients.USBDeviceClaimsClient(client.DevicesV1beta1().USBDeviceClaims), fakeclients.USBDevicesClient(client.DevicesV1beta1().USBDevices), fakeclients.KubeVirtClient(client.KubevirtV1().KubeVirts), make(chan struct{}))
 
 				// Test claim created
 				mockUsbDeviceClaim1.Name = "non-exist"

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -83,6 +83,14 @@ func GetVFList(pfDir string) (vfList []string, err error) {
 	return
 }
 
+func VMBySpecHostDeviceName(obj *kubevirtv1.VirtualMachine) ([]string, error) {
+	hostDeviceName := make([]string, 0, len(obj.Spec.Template.Spec.Domain.Devices.HostDevices))
+	for _, hostDevice := range obj.Spec.Template.Spec.Domain.Devices.HostDevices {
+		hostDeviceName = append(hostDeviceName, hostDevice.Name)
+	}
+	return hostDeviceName, nil
+}
+
 // VMByHostDeviceName indexes VM's by host device name.
 // It could be usb device claim or pci device claim name.
 func VMByHostDeviceName(obj *kubevirtv1.VirtualMachine) ([]string, error) {

--- a/pkg/webhook/indexer.go
+++ b/pkg/webhook/indexer.go
@@ -23,7 +23,9 @@ func RegisterIndexers(clients *Clients) {
 	vmCache := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmCache.AddIndexer(VMByName, vmByName)
 	vmCache.AddIndexer(VMByPCIDeviceClaim, common.VMByHostDeviceName)
-	vmCache.AddIndexer(VMByUSBDeviceClaim, common.VMByHostDeviceName)
+	// Because USB device don't have same problem which vGPU and PCI device have,
+	// so we just need to use a simple way to collect the host device names.
+	vmCache.AddIndexer(VMByUSBDeviceClaim, common.VMBySpecHostDeviceName)
 	vmCache.AddIndexer(VMByVGPU, common.VMByVGPUDevice)
 	deviceCache := clients.DeviceFactory.Devices().V1beta1().PCIDevice().Cache()
 	deviceCache.AddIndexer(PCIDeviceByResourceName, pciDeviceByResourceName)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Steps:

- Plugin USB device
- Enable device (Don't need to attach it to a VM)
- Unplug USB device
- Plugin USB device again

There are two USB device listed on the page, one of them is orphaned.

**Solution:**
Case A: If that orphaned USB device is enabled and unattached, just remove it directly.
Case B: if that orphaned USB device is enabled and attached to a VM, just update status. I think GUI can show message to users in the future.

Additional fix is that deleting attached USB device claim should be forbidden.

**Related Issue:**
https://github.com/harvester/harvester/issues/6720

**Test plan:**
Follow above steps to test it.
