### PR TITLE
fix: check group map before enable pci device passthrough

### DIFF
--- a/pkg/iommu/iommu.go
+++ b/pkg/iommu/iommu.go
@@ -53,3 +53,17 @@ func GroupPaths() ([]string, error) {
 	}
 	return groupPaths, nil
 }
+
+func GetGroupMap(address string) (string, error) {
+	iommuGroupPaths, err := GroupPaths()
+	if err != nil {
+		return "", err
+	}
+
+	iommuGroupMap := GroupMapForPCIDevices(iommuGroupPaths)
+	if group, found := iommuGroupMap[address]; found {
+		return strconv.Itoa(group), nil
+	}
+
+	return "", fmt.Errorf("missing group for address: %s", address)
+}


### PR DESCRIPTION
**Problem:**
PCIDevice's device plugin uses an out-of-date group after node rebooting

**Solution:**
check the group map before enabling PCIDevice device plugin

**Related Issue:**
https://github.com/harvester/harvester/issues/6892

**Test plan:**
- Enabling a PCIDevice
- Creating a VM attach the PCIDevice
- After starting the VM successfully, rebooting the node
- Checking if the VM can start successfully across node rebooting