### PR TITLE
feat: check usb/pci/gpu resource name

### DIFF
--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -166,3 +166,7 @@ func generateHostDeviceAllocation(obj *kubevirtv1.VirtualMachine, allocationDeta
 	}
 	return nil, nil
 }
+
+func USBDeviceByResourceName(obj *v1beta1.USBDevice) ([]string, error) {
+	return []string{obj.Status.ResourceName}, nil
+}

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -169,4 +170,24 @@ func generateHostDeviceAllocation(obj *kubevirtv1.VirtualMachine, allocationDeta
 
 func USBDeviceByResourceName(obj *v1beta1.USBDevice) ([]string, error) {
 	return []string{obj.Status.ResourceName}, nil
+}
+
+func VGPUDeviceByResourceName(obj *v1beta1.VGPUDevice) ([]string, error) {
+	return []string{
+		GeneratevGPUDeviceName(obj.Status.ConfiguredVGPUTypeName),
+	}, nil
+}
+
+func GeneratevGPUDeviceName(deviceName string) string {
+	deviceName = strings.TrimSpace(deviceName)
+	deviceName = strings.ToUpper(deviceName)
+	deviceName = strings.Replace(deviceName, "/", "_", -1)
+	deviceName = strings.Replace(deviceName, ".", "_", -1)
+	//deviceName = strings.Replace(deviceName, "-", "_", -1)
+	reg, _ := regexp.Compile(`\s+`)
+	deviceName = reg.ReplaceAllString(deviceName, "_")
+	// Removes any char other than alphanumeric and underscore
+	reg, _ = regexp.Compile(`^a-zA-Z0-9_-.]+`)
+	deviceName = reg.ReplaceAllString(deviceName, "")
+	return fmt.Sprintf("nvidia.com/%s", deviceName)
 }

--- a/pkg/util/fakeclients/pcidevices.go
+++ b/pkg/util/fakeclients/pcidevices.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	IommuGroupByNode = "pcidevice.harvesterhci.io/iommu-by-node"
+	IommuGroupByNode        = "pcidevice.harvesterhci.io/iommu-by-node"
+	PCIDeviceByResourceName = "harvesterhcio.io/pcidevice-by-resource-name"
 )
 
 type PCIDevicesClient func() v1beta1.PCIDeviceInterface
@@ -80,6 +81,18 @@ func (p PCIDevicesCache) GetByIndex(indexName, key string) ([]*pcidevicev1beta1.
 			}
 		}
 		return resp, err
+	case PCIDeviceByResourceName:
+		list, err := p().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		var resp []*pcidevicev1beta1.PCIDevice
+		for i, v := range list.Items {
+			if key == v.Status.ResourceName {
+				resp = append(resp, &list.Items[i])
+			}
+		}
+		return resp, nil
 	default:
 		return nil, nil
 	}

--- a/pkg/util/fakeclients/usbdevice.go
+++ b/pkg/util/fakeclients/usbdevice.go
@@ -13,6 +13,8 @@ import (
 	devicesv1beta1ctl "github.com/harvester/pcidevices/pkg/generated/controllers/devices.harvesterhci.io/v1beta1"
 )
 
+const USBDeviceByResourceName = "harvesterhci.io/usbdevice-by-resource-name"
+
 type USBDevicesClient func() v1beta1.USBDeviceInterface
 
 func (p USBDevicesClient) Update(d *devicev1beta1.USBDevice) (*devicev1beta1.USBDevice, error) {
@@ -76,6 +78,23 @@ func (p USBDeviceCache) AddIndexer(_ string, _ devicesv1beta1ctl.USBDeviceIndexe
 	panic("implement me")
 }
 
-func (p USBDeviceCache) GetByIndex(_, _ string) ([]*devicev1beta1.USBDevice, error) {
-	panic("implement me")
+func (p USBDeviceCache) GetByIndex(indexName, name string) ([]*devicev1beta1.USBDevice, error) {
+	switch indexName {
+	case USBDeviceByResourceName:
+		var usbDevices []*devicev1beta1.USBDevice
+		devices, err := p.List(labels.NewSelector())
+		if err != nil {
+			return []*devicev1beta1.USBDevice{}, err
+		}
+
+		for _, device := range devices {
+			if device.Status.ResourceName == name {
+				usbDevices = append(usbDevices, device)
+			}
+		}
+		return usbDevices, err
+	default:
+	}
+
+	return []*devicev1beta1.USBDevice{}, nil
 }

--- a/pkg/util/fakeclients/vgpudevice.go
+++ b/pkg/util/fakeclients/vgpudevice.go
@@ -11,7 +11,10 @@ import (
 	pcidevicev1beta1 "github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
 	"github.com/harvester/pcidevices/pkg/generated/clientset/versioned/typed/devices.harvesterhci.io/v1beta1"
 	pcidevicesv1beta1ctl "github.com/harvester/pcidevices/pkg/generated/controllers/devices.harvesterhci.io/v1beta1"
+	"github.com/harvester/pcidevices/pkg/util/common"
 )
+
+const vGPUDeviceByResourceName = "harvesterhci.io/vgpu-device-by-resource-name"
 
 type VGPUDeviceClient func() v1beta1.VGPUDeviceInterface
 
@@ -72,6 +75,21 @@ func (s VGPUDeviceCache) AddIndexer(_ string, _ pcidevicesv1beta1ctl.VGPUDeviceI
 	panic("implement me")
 }
 
-func (s VGPUDeviceCache) GetByIndex(_, _ string) ([]*pcidevicev1beta1.VGPUDevice, error) {
-	panic("implement me")
+func (s VGPUDeviceCache) GetByIndex(index, key string) ([]*pcidevicev1beta1.VGPUDevice, error) {
+	switch index {
+	case vGPUDeviceByResourceName:
+		devices, err := s.List(labels.NewSelector())
+		if err != nil {
+			return nil, err
+		}
+		for _, device := range devices {
+			if common.GeneratevGPUDeviceName(device.Status.ConfiguredVGPUTypeName) == key {
+				return []*pcidevicev1beta1.VGPUDevice{device}, nil
+			}
+		}
+		return nil, nil
+	default:
+	}
+
+	return nil, nil
 }

--- a/pkg/util/gpuhelper/gpuhelper.go
+++ b/pkg/util/gpuhelper/gpuhelper.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -295,15 +294,5 @@ func evalPhysFn(devicePath string) (string, error) {
 }
 
 func GenerateDeviceName(deviceName string) string {
-	deviceName = strings.TrimSpace(deviceName)
-	deviceName = strings.ToUpper(deviceName)
-	deviceName = strings.Replace(deviceName, "/", "_", -1)
-	deviceName = strings.Replace(deviceName, ".", "_", -1)
-	//deviceName = strings.Replace(deviceName, "-", "_", -1)
-	reg, _ := regexp.Compile(`\s+`)
-	deviceName = reg.ReplaceAllString(deviceName, "_")
-	// Removes any char other than alphanumeric and underscore
-	reg, _ = regexp.Compile(`^a-zA-Z0-9_-.]+`)
-	deviceName = reg.ReplaceAllString(deviceName, "")
-	return fmt.Sprintf("nvidia.com/%s", deviceName)
+	return common.GeneratevGPUDeviceName(deviceName)
 }

--- a/pkg/webhook/indexer.go
+++ b/pkg/webhook/indexer.go
@@ -10,14 +10,15 @@ import (
 )
 
 const (
-	VMByName                = "harvesterhci.io/vm-by-name"
-	PCIDeviceByResourceName = "harvesterhcio.io/pcidevice-by-resource-name"
-	IommuGroupByNode        = "pcidevice.harvesterhci.io/iommu-by-node"
-	USBDeviceByAddress      = "pcidevice.harvesterhci.io/usb-device-by-address"
-	VMByPCIDeviceClaim      = "harvesterhci.io/vm-by-pcideviceclaim"
-	VMByUSBDeviceClaim      = "harvesterhci.io/vm-by-usbdeviceclaim"
-	VMByVGPU                = "harvesterhci.io/vm-by-vgpu"
-	USBDeviceByResourceName = "harvesterhci.io/usbdevice-by-resource-name"
+	VMByName                 = "harvesterhci.io/vm-by-name"
+	PCIDeviceByResourceName  = "harvesterhcio.io/pcidevice-by-resource-name"
+	IommuGroupByNode         = "pcidevice.harvesterhci.io/iommu-by-node"
+	USBDeviceByAddress       = "pcidevice.harvesterhci.io/usb-device-by-address"
+	VMByPCIDeviceClaim       = "harvesterhci.io/vm-by-pcideviceclaim"
+	VMByUSBDeviceClaim       = "harvesterhci.io/vm-by-usbdeviceclaim"
+	VMByVGPU                 = "harvesterhci.io/vm-by-vgpu"
+	USBDeviceByResourceName  = "harvesterhci.io/usbdevice-by-resource-name"
+	vGPUDeviceByResourceName = "harvesterhci.io/vgpu-device-by-resource-name"
 )
 
 func RegisterIndexers(clients *Clients) {
@@ -35,6 +36,8 @@ func RegisterIndexers(clients *Clients) {
 	usbDeviceCache.AddIndexer(USBDeviceByResourceName, common.USBDeviceByResourceName)
 	usbDeviceClaimCache := clients.DeviceFactory.Devices().V1beta1().USBDeviceClaim().Cache()
 	usbDeviceClaimCache.AddIndexer(USBDeviceByAddress, usbDeviceClaimByAddress)
+	vgpuCache := clients.DeviceFactory.Devices().V1beta1().VGPUDevice().Cache()
+	vgpuCache.AddIndexer(vGPUDeviceByResourceName, common.VGPUDeviceByResourceName)
 }
 
 func vmByName(obj *kubevirtv1.VirtualMachine) ([]string, error) {

--- a/pkg/webhook/indexer.go
+++ b/pkg/webhook/indexer.go
@@ -17,6 +17,7 @@ const (
 	VMByPCIDeviceClaim      = "harvesterhci.io/vm-by-pcideviceclaim"
 	VMByUSBDeviceClaim      = "harvesterhci.io/vm-by-usbdeviceclaim"
 	VMByVGPU                = "harvesterhci.io/vm-by-vgpu"
+	USBDeviceByResourceName = "harvesterhci.io/usbdevice-by-resource-name"
 )
 
 func RegisterIndexers(clients *Clients) {
@@ -30,6 +31,8 @@ func RegisterIndexers(clients *Clients) {
 	deviceCache := clients.DeviceFactory.Devices().V1beta1().PCIDevice().Cache()
 	deviceCache.AddIndexer(PCIDeviceByResourceName, pciDeviceByResourceName)
 	deviceCache.AddIndexer(IommuGroupByNode, iommuGroupByNodeName)
+	usbDeviceCache := clients.DeviceFactory.Devices().V1beta1().USBDevice().Cache()
+	usbDeviceCache.AddIndexer(USBDeviceByResourceName, common.USBDeviceByResourceName)
 	usbDeviceClaimCache := clients.DeviceFactory.Devices().V1beta1().USBDeviceClaim().Cache()
 	usbDeviceClaimCache.AddIndexer(USBDeviceByAddress, usbDeviceClaimByAddress)
 }

--- a/pkg/webhook/mutation.go
+++ b/pkg/webhook/mutation.go
@@ -17,7 +17,8 @@ func Mutation(clients *Clients) (http.Handler, []types.Resource, error) {
 			clients.DeviceFactory.Devices().V1beta1().VGPUDevice().Cache()),
 		NewPCIVMMutator(clients.DeviceFactory.Devices().V1beta1().PCIDevice().Cache(),
 			clients.DeviceFactory.Devices().V1beta1().PCIDeviceClaim().Cache(),
-			clients.DeviceFactory.Devices().V1beta1().PCIDeviceClaim()),
+			clients.DeviceFactory.Devices().V1beta1().PCIDeviceClaim(),
+		),
 	}
 
 	router := webhook.NewRouter()

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -19,7 +19,10 @@ func Validation(clients *Clients) (http.Handler, []types.Resource, error) {
 		NewVGPUValidator(clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
 		NewSRIOVGPUValidator(clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
 		NewUSBDeviceClaimValidator(clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
-		NewDeviceHostValidation(clients.DeviceFactory.Devices().V1beta1().USBDevice().Cache(), clients.DeviceFactory.Devices().V1beta1().PCIDevice().Cache()),
+		NewDeviceHostValidation(
+			clients.DeviceFactory.Devices().V1beta1().USBDevice().Cache(),
+			clients.DeviceFactory.Devices().V1beta1().PCIDevice().Cache(),
+		),
 		NewUSBDeviceValidator(),
 	}
 

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -22,6 +22,7 @@ func Validation(clients *Clients) (http.Handler, []types.Resource, error) {
 		NewDeviceHostValidation(
 			clients.DeviceFactory.Devices().V1beta1().USBDevice().Cache(),
 			clients.DeviceFactory.Devices().V1beta1().PCIDevice().Cache(),
+			clients.DeviceFactory.Devices().V1beta1().VGPUDevice().Cache(),
 		),
 		NewUSBDeviceValidator(),
 	}

--- a/pkg/webhook/vm_validataion_test.go
+++ b/pkg/webhook/vm_validataion_test.go
@@ -11,6 +11,7 @@ import (
 	devicesv1beta1 "github.com/harvester/pcidevices/pkg/apis/devices.harvesterhci.io/v1beta1"
 	"github.com/harvester/pcidevices/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/pcidevices/pkg/util/fakeclients"
+	"github.com/harvester/pcidevices/pkg/util/gpuhelper"
 )
 
 var (
@@ -44,6 +45,24 @@ var (
 		},
 	}
 
+	vgpudeviceinnode1 = &devicesv1beta1.VGPUDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vgpu-upgrade-test-000008005",
+		},
+		Spec: devicesv1beta1.VGPUDeviceSpec{
+			Address:                "0000:08:00.5",
+			Enabled:                true,
+			NodeName:               "vgpu-upgrade-test",
+			ParentGPUDeviceAddress: "0000:08:00.0",
+			VGPUTypeName:           "NVIDIA A2-2Q",
+		},
+		Status: devicesv1beta1.VGPUDeviceStatus{
+			ConfiguredVGPUTypeName: "NVIDIA A2-2Q",
+			UUID:                   "f2285cf1-0aaa-4d05-af20-78cec22f02c7",
+			VGPUStatus:             "vGPUConfigured",
+		},
+	}
+
 	vmWithTwoInSameNodeDevices = &kubevirtv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vm-with-usb-devices2",
@@ -74,29 +93,37 @@ var (
 
 func Test_CreateVM(t *testing.T) {
 
+	type input struct {
+		usbDevice  *devicesv1beta1.USBDevice
+		pciDevice  *devicesv1beta1.PCIDevice
+		vgpuDevice *devicesv1beta1.VGPUDevice
+		vm         *kubevirtv1.VirtualMachine
+	}
+
 	testcases := []struct {
 		name   string
 		err    error
-		before func(usbdevice2innode1Cp *devicesv1beta1.USBDevice, pcideviceinnode1Cp *devicesv1beta1.PCIDevice, vmWithTwoInSameNodeDevicesCp *kubevirtv1.VirtualMachine)
+		before func(in input)
 	}{
 		{
-			name:   "matched node name",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, _ *kubevirtv1.VirtualMachine) {},
-			err:    nil,
+			name: "matched node name",
+			before: func(_ input) {
+			},
+			err: nil,
 		},
 		{
 			name: "mismatched node name - mismatched usb device",
-			before: func(usbdevice2innode1Cp *devicesv1beta1.USBDevice, pcideviceinnode1Cp *devicesv1beta1.PCIDevice, vmWithTwoInSameNodeDevicesCp *kubevirtv1.VirtualMachine) {
-				usbdevice2innode1Cp.Status.NodeName = "node2"
+			before: func(in input) {
+				in.usbDevice.Status.NodeName = "node2"
 				// change order to trigger usb device is mismatched
-				vmWithTwoInSameNodeDevicesCp.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{
 					{
-						Name:       pcideviceinnode1Cp.Name,
-						DeviceName: pcideviceinnode1Cp.Status.ResourceName,
+						Name:       in.pciDevice.Name,
+						DeviceName: in.pciDevice.Status.ResourceName,
 					},
 					{
-						Name:       usbdevice2innode1Cp.Name,
-						DeviceName: usbdevice2innode1Cp.Status.ResourceName,
+						Name:       in.usbDevice.Name,
+						DeviceName: in.usbDevice.Status.ResourceName,
 					},
 				}
 			},
@@ -104,47 +131,47 @@ func Test_CreateVM(t *testing.T) {
 		},
 		{
 			name: "mismatched node name - mismatched pci device",
-			before: func(_ *devicesv1beta1.USBDevice, pcideviceinnode1Cp *devicesv1beta1.PCIDevice, _ *kubevirtv1.VirtualMachine) {
-				pcideviceinnode1Cp.Status.NodeName = "node2"
+			before: func(in input) {
+				in.pciDevice.Status.NodeName = "node2"
 			},
 			err: errors.New("device pcidevice/node1dev1noiommu is not on the same node in VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices vm-with-usb-devices2"),
 		},
 		{
 			name: "usb device name is different from CR, it should be able to create",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].Name = "tempusbdevice"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].Name = "tempusbdevice"
 			},
 			err: nil,
 		},
 		{
 			name: "mismatched usb resource name ",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].DeviceName = "fake.com/device2"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].DeviceName = "fake.com/device2"
 			},
 			err: errors.New("hostdevice usbdevice2innode1: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
 		},
 		{
 			name: "pci device name is different from CR, it should be able to create",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].Name = "temppcidevice"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].Name = "temppcidevice"
 			},
 			err: nil,
 		},
 		{
 			name: "mismatched pci resource name ",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].DeviceName = "fake.com/device2"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].DeviceName = "fake.com/device2"
 			},
 			err: errors.New("hostdevice node1dev1noiommu: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
 		},
 		{
 			name: "gpu device name is different from CR, it should be able to create",
-			before: func(_ *devicesv1beta1.USBDevice, pcideviceinnode1cp *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
-				vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
+				in.vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
 					{
-						Name:       pcideviceinnode1cp.Name + "fake",
-						DeviceName: pcideviceinnode1cp.Status.ResourceName,
+						Name:       in.vgpuDevice.Name + "fake",
+						DeviceName: gpuhelper.GenerateDeviceName(in.vgpuDevice.Status.ConfiguredVGPUTypeName),
 					},
 				}
 			},
@@ -152,35 +179,35 @@ func Test_CreateVM(t *testing.T) {
 		},
 		{
 			name: "mismatched gpu resource name ",
-			before: func(_ *devicesv1beta1.USBDevice, pcideviceinnode1cp *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
-				vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
+				in.vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
 					{
-						Name:       pcideviceinnode1cp.Name,
-						DeviceName: pcideviceinnode1cp.Status.ResourceName + "fake",
+						Name:       in.vgpuDevice.Name,
+						DeviceName: gpuhelper.GenerateDeviceName(in.vgpuDevice.Status.ConfiguredVGPUTypeName) + "fake",
 					},
 				}
 			},
-			err: errors.New("gpu device node1dev1noiommu: resource name fake.com/device1fake not found in pcidevice cache"),
+			err: errors.New("gpu device vgpu-upgrade-test-000008005: resource name nvidia.com/NVIDIA_A2-2Qfake not found in pcidevice cache"),
 		},
 	}
 
 	for _, tc := range testcases {
-		pcideviceinnode1Cp := pcideviceinnode1.DeepCopy()
-		usbdevice2innode1Cp := usbdevice2innode1.DeepCopy()
-		vmWithTwoInSameNodeDevicesCp := vmWithTwoInSameNodeDevices.DeepCopy()
-		tc.before(
-			usbdevice2innode1Cp,
-			pcideviceinnode1Cp,
-			vmWithTwoInSameNodeDevicesCp,
-		)
+		in := input{
+			pciDevice:  pcideviceinnode1.DeepCopy(),
+			usbDevice:  usbdevice2innode1.DeepCopy(),
+			vgpuDevice: vgpudeviceinnode1.DeepCopy(),
+			vm:         vmWithTwoInSameNodeDevices.DeepCopy(),
+		}
+		tc.before(in)
 
-		fakeClient := fake.NewSimpleClientset(usbdevice2innode1Cp, pcideviceinnode1Cp)
+		fakeClient := fake.NewSimpleClientset(in.vgpuDevice, in.pciDevice, in.usbDevice)
 		usbCache := fakeclients.USBDeviceCache(fakeClient.DevicesV1beta1().USBDevices)
 		pciCache := fakeclients.PCIDevicesCache(fakeClient.DevicesV1beta1().PCIDevices)
+		vGPUCache := fakeclients.VGPUDeviceCache(fakeClient.DevicesV1beta1().VGPUDevices)
 
-		validator := NewDeviceHostValidation(usbCache, pciCache)
-		err := validator.Create(nil, vmWithTwoInSameNodeDevicesCp)
+		validator := NewDeviceHostValidation(usbCache, pciCache, vGPUCache)
+		err := validator.Create(nil, in.vm)
 
 		assert.Equal(t, tc.err, err, tc.name)
 	}
@@ -188,30 +215,37 @@ func Test_CreateVM(t *testing.T) {
 
 func Test_UpdateVM(t *testing.T) {
 
+	type input struct {
+		usbDevice  *devicesv1beta1.USBDevice
+		pciDevice  *devicesv1beta1.PCIDevice
+		vgpuDevice *devicesv1beta1.VGPUDevice
+		vm         *kubevirtv1.VirtualMachine
+	}
+
 	testcases := []struct {
 		name   string
 		err    error
-		before func(usbdevice2innode1Cp *devicesv1beta1.USBDevice, pcideviceinnode1Cp *devicesv1beta1.PCIDevice, vmWithTwoInSameNodeDevicesCp *kubevirtv1.VirtualMachine)
+		before func(in input)
 	}{
 		{
 			name: "matched node name",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, _ *kubevirtv1.VirtualMachine) {
+			before: func(_ input) {
 			},
 			err: nil,
 		},
 		{
 			name: "mismatched node name - mismatched usb device",
-			before: func(usbdevice2innode1Cp *devicesv1beta1.USBDevice, pcideviceinnode1Cp *devicesv1beta1.PCIDevice, vmWithTwoInSameNodeDevicesCp *kubevirtv1.VirtualMachine) {
-				usbdevice2innode1Cp.Status.NodeName = "node2"
+			before: func(in input) {
+				in.usbDevice.Status.NodeName = "node2"
 				// change order to trigger usb device is mismatched
-				vmWithTwoInSameNodeDevicesCp.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{
 					{
-						Name:       pcideviceinnode1Cp.Name,
-						DeviceName: pcideviceinnode1Cp.Status.ResourceName,
+						Name:       in.pciDevice.Name,
+						DeviceName: in.pciDevice.Status.ResourceName,
 					},
 					{
-						Name:       usbdevice2innode1Cp.Name,
-						DeviceName: usbdevice2innode1Cp.Status.ResourceName,
+						Name:       in.usbDevice.Name,
+						DeviceName: in.usbDevice.Status.ResourceName,
 					},
 				}
 			},
@@ -219,47 +253,47 @@ func Test_UpdateVM(t *testing.T) {
 		},
 		{
 			name: "mismatched node name - mismatched pci device",
-			before: func(_ *devicesv1beta1.USBDevice, pcideviceinnode1Cp *devicesv1beta1.PCIDevice, _ *kubevirtv1.VirtualMachine) {
-				pcideviceinnode1Cp.Status.NodeName = "node2"
+			before: func(in input) {
+				in.pciDevice.Status.NodeName = "node2"
 			},
 			err: errors.New("device pcidevice/node1dev1noiommu is not on the same node in VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices vm-with-usb-devices2"),
 		},
 		{
 			name: "usb device name is different from CR, it should be able to create",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].Name = "tempusbdevice"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].Name = "tempusbdevice"
 			},
 			err: nil,
 		},
 		{
 			name: "mismatched usb resource name ",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].DeviceName = "fake.com/device2"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].DeviceName = "fake.com/device2"
 			},
 			err: errors.New("hostdevice usbdevice2innode1: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
 		},
 		{
 			name: "pci device name is different from CR, it should be able to create",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].Name = "temppcidevice"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].Name = "temppcidevice"
 			},
 			err: nil,
 		},
 		{
 			name: "mismatched pci resource name ",
-			before: func(_ *devicesv1beta1.USBDevice, _ *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].DeviceName = "fake.com/device2"
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].DeviceName = "fake.com/device2"
 			},
 			err: errors.New("hostdevice node1dev1noiommu: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
 		},
 		{
 			name: "gpu device name is different from CR, it should be able to create",
-			before: func(_ *devicesv1beta1.USBDevice, pcideviceinnode1cp *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
-				vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
+				in.vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
 					{
-						Name:       pcideviceinnode1cp.Name + "fake",
-						DeviceName: pcideviceinnode1cp.Status.ResourceName,
+						Name:       in.vgpuDevice.Name + "fake",
+						DeviceName: gpuhelper.GenerateDeviceName(in.vgpuDevice.Status.ConfiguredVGPUTypeName),
 					},
 				}
 			},
@@ -267,32 +301,35 @@ func Test_UpdateVM(t *testing.T) {
 		},
 		{
 			name: "mismatched gpu resource name ",
-			before: func(_ *devicesv1beta1.USBDevice, pcideviceinnode1cp *devicesv1beta1.PCIDevice, vm *kubevirtv1.VirtualMachine) {
-				vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
-				vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
+			before: func(in input) {
+				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices = []kubevirtv1.HostDevice{}
+				in.vm.Spec.Template.Spec.Domain.Devices.GPUs = []kubevirtv1.GPU{
 					{
-						Name:       pcideviceinnode1cp.Name,
-						DeviceName: pcideviceinnode1cp.Status.ResourceName + "fake",
+						Name:       in.vgpuDevice.Name,
+						DeviceName: gpuhelper.GenerateDeviceName(in.vgpuDevice.Status.ConfiguredVGPUTypeName) + "fake",
 					},
 				}
 			},
-			err: errors.New("gpu device node1dev1noiommu: resource name fake.com/device1fake not found in pcidevice cache"),
+			err: errors.New("gpu device vgpu-upgrade-test-000008005: resource name nvidia.com/NVIDIA_A2-2Qfake not found in pcidevice cache"),
 		},
 	}
 
 	for _, tc := range testcases {
-		pcideviceinnode1Cp := pcideviceinnode1.DeepCopy()
-		usbdevice2innode1Cp := usbdevice2innode1.DeepCopy()
-		vmWithTwoInSameNodeDevicesCp := vmWithTwoInSameNodeDevices.DeepCopy()
+		in := input{
+			pciDevice:  pcideviceinnode1.DeepCopy(),
+			usbDevice:  usbdevice2innode1.DeepCopy(),
+			vgpuDevice: vgpudeviceinnode1.DeepCopy(),
+			vm:         vmWithTwoInSameNodeDevices.DeepCopy(),
+		}
+		tc.before(in)
 
-		tc.before(usbdevice2innode1Cp, pcideviceinnode1Cp, vmWithTwoInSameNodeDevicesCp)
-
-		fakeClient := fake.NewSimpleClientset(usbdevice2innode1Cp, pcideviceinnode1Cp)
+		fakeClient := fake.NewSimpleClientset(in.vgpuDevice, in.pciDevice, in.usbDevice)
 		usbCache := fakeclients.USBDeviceCache(fakeClient.DevicesV1beta1().USBDevices)
 		pciCache := fakeclients.PCIDevicesCache(fakeClient.DevicesV1beta1().PCIDevices)
+		vGPUCache := fakeclients.VGPUDeviceCache(fakeClient.DevicesV1beta1().VGPUDevices)
 
-		validator := NewDeviceHostValidation(usbCache, pciCache)
-		err := validator.Update(nil, nil, vmWithTwoInSameNodeDevicesCp)
+		validator := NewDeviceHostValidation(usbCache, pciCache, vGPUCache)
+		err := validator.Update(nil, nil, in.vm)
 
 		assert.Equal(t, tc.err, err, tc.name)
 	}

--- a/pkg/webhook/vm_validatation.go
+++ b/pkg/webhook/vm_validatation.go
@@ -44,29 +44,15 @@ func NewDeviceHostValidation(usbCache v1beta1.USBDeviceCache, pciCache v1beta1.P
 
 func (vmValidator *vmDeviceHostValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	vmObj := newObj.(*kubevirtv1.VirtualMachine)
-
-	if len(vmObj.Spec.Template.Spec.Domain.Devices.HostDevices) != 0 {
-		if err := vmValidator.validateHostDevices(vmObj); err != nil {
-			return err
-		}
-
-		if err := vmValidator.validateDevicesFromSameNodes(vmObj); err != nil {
-			return err
-		}
-	}
-
-	if len(vmObj.Spec.Template.Spec.Domain.Devices.GPUs) != 0 {
-		if err := vmValidator.validateGPUs(vmObj); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return vmValidator.validateDevices(vmObj)
 }
 
 func (vmValidator *vmDeviceHostValidator) Update(_ *types.Request, _ runtime.Object, newObj runtime.Object) error {
 	vmObj := newObj.(*kubevirtv1.VirtualMachine)
+	return vmValidator.validateDevices(vmObj)
+}
 
+func (vmValidator *vmDeviceHostValidator) validateDevices(vmObj *kubevirtv1.VirtualMachine) error {
 	if len(vmObj.Spec.Template.Spec.Domain.Devices.HostDevices) != 0 {
 		if err := vmValidator.validateHostDevices(vmObj); err != nil {
 			return err


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
When creating or updating a non-existed pci/usb resource name, it's allowed. Besides, vGPU device is not checked either.

**Solution:**
We should check `.DeviceName` in VM spec while creating or updating. BTW, vGPU device is in the other field, so we need to check it in `spec.template.domain.devices.gpus`.

> .DeviceName means **resource name** in k8s.

**Related Issue:**
https://github.com/harvester/harvester/issues/6542

**Test plan:**

#### Test PCI Device

1. Enable pcidevices-controller Add-on
2. Enable one of PCI devices
3. Create a VM and attach previous PCI device
4. Click "Edit as YAML" button to manually edit YAML file, then click "Create" button.
5. Modify the `.DeviceName` in the spec.template.domain.devices.hostDevices.

If you're not sure how to do it, please refer following demo recording.

https://github.com/user-attachments/assets/fd2336e6-8bc9-49ba-81e9-a23661ede5a5


#### Test USB Device

1. Enable pcidevices-controller Add-on
2. Enable one of USB devices
3. Create a VM and attach previous USB device
4. Click "Edit as YAML" button to manually edit YAML file, then click "Create" button.
5. Modify the `.DeviceName` in the spec.template.domain.devices.hostDevices.

If you're not sure how to do it, please refer following demo recording.

https://github.com/user-attachments/assets/3f548d07-d4e0-48c2-a5be-5287b99eadcc