### PR TITLE
fix: add checking vfio modules logic

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.5/hardw
     zypper -n install bash git gcc docker vim less file curl wget ca-certificates pciutils umockdev awk jq
 RUN go install golang.org/x/lint/golint@latest
 RUN go install golang.org/x/tools/cmd/goimports@latest
-RUN go install github.com/incu6us/goimports-reviser/v3@latest
+RUN go install github.com/incu6us/goimports-reviser/v3@v3.8.2
 RUN export K8S_VERSION=1.24.2 && \
     curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)" && \
     mkdir /usr/local/kubebuilder && \

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -160,12 +160,12 @@ func loadVfioDrivers() {
 }
 
 func checkVFIOModules() (bool, error) {
-	return checkModulesExists([]string{"vfio_pci", "vfio_iommu_type1"})
+	return checkModulesExists("/proc/modules", []string{"vfio_pci", "vfio_iommu_type1"})
 }
 
 // checkModulesExists checks the /proc/modules file to see if a module exists
-func checkModulesExists(modules []string) (bool, error) {
-	fd, err := os.Open("/proc/modules")
+func checkModulesExists(filename string, modules []string) (bool, error) {
+	fd, err := os.Open(filename)
 	if err != nil {
 		return false, fmt.Errorf("failed to open /proc/modules: %v", err)
 	}

--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller_test.go
@@ -165,3 +165,16 @@ func Test_permitHostDeviceInKubevirtWithExternalResourceDevices(t *testing.T) {
 	assert.Len(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices, 1, "expected to find one device added")
 	assert.True(kvCopy.Spec.Configuration.PermittedHostDevices.PciHostDevices[0].ExternalResourceProvider, "expected external resource provider to be updated")
 }
+
+func Test_checkModulesExists(t *testing.T) {
+	assert := require.New(t)
+	modules := []string{"vfio", "vfio_iommu_type1"}
+	found, err := checkModulesExists("../../../tests/manifests/modules", modules)
+	assert.NoError(err)
+	assert.True(found)
+
+	modules = []string{"dummy"}
+	found, err = checkModulesExists("../../../tests/manifests/modules", modules)
+	assert.NoError(err)
+	assert.False(found)
+}

--- a/tests/manifests/modules
+++ b/tests/manifests/modules
@@ -1,0 +1,6 @@
+vfio_iommu_type1       40960  0
+vfio_pci               16384  0
+vfio_pci_core          69632  1 vfio_pci
+vfio                   32768  2 vfio_pci_core,vfio_iommu_type1
+vfio_virqfd            16384  1 vfio_pci_core
+irqbypass              16384  2 vfio_pci_core,kvm


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We observed that when there are no bound devices, vfio module is unloaded in few hours.

**Solution:**
Check vfio module before passing through the pci devices.

**Related Issue:**
- Main issue https://github.com/harvester/harvester/issues/7815
- Raised from https://github.com/harvester/harvester/issues/7354#issuecomment-2702694695

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
