### PR TITLE
minor fix for handling vGPUs when using NVIDIA RTX5000 Ada devices

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.5/hardw
     zypper -n install bash git gcc docker vim less file curl wget ca-certificates pciutils umockdev awk jq
 RUN go install golang.org/x/lint/golint@latest
 RUN go install golang.org/x/tools/cmd/goimports@latest
-RUN go install github.com/incu6us/goimports-reviser/v3@latest
+RUN go install github.com/incu6us/goimports-reviser/v3@v3.8.2
 RUN export K8S_VERSION=1.24.2 && \
     curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)" && \
     mkdir /usr/local/kubebuilder && \

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -180,7 +180,7 @@ func VGPUDeviceByResourceName(obj *v1beta1.VGPUDevice) ([]string, error) {
 
 func GeneratevGPUDeviceName(deviceName string) string {
 	deviceName = strings.TrimSpace(deviceName)
-	deviceName = strings.ToUpper(deviceName)
+	//deviceName = strings.ToUpper(deviceName)
 	deviceName = strings.Replace(deviceName, "/", "_", -1)
 	deviceName = strings.Replace(deviceName, ".", "_", -1)
 	//deviceName = strings.Replace(deviceName, "-", "_", -1)


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Some nvidia vGPU profiles have a lower case character in their name.
This breaks vgpu device passthrough to the workloads as the kubevirt cr permitted devices does not match the actual vgpu profile.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
minor change to vgpu device name generation where we do not force conversion to upper case characters as some devices like RTX5000 ADA preent the vgpu types as RTX5000-Ada which results in device plugin name not matching the actual gpu profile


**Related Issue:**
https://github.com/harvester/harvester/issues/6294
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
