### PR TITLE
fix broken CI

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM registry.suse.com/bci/golang:1.23
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.5/hardware.repo && \
+RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.6/hardware.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n install bash git gcc docker vim less file curl wget ca-certificates pciutils umockdev awk jq
 RUN go install golang.org/x/lint/golint@latest


### PR DESCRIPTION
Currently CI is broken as the hardware repo for opensuse 15.5 has been removed.

The PR introduces a minor bump to update the hardware repo to use opensue 15.6 repos

