### PR TITLE
ci fixes for v1.4 head

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,12 +3,13 @@ FROM registry.suse.com/bci/golang:1.22.7
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.5/hardware.repo && \
+RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.6/hardware.repo && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n install bash git gcc docker vim less file curl wget ca-certificates pciutils umockdev awk jq
 RUN go install golang.org/x/lint/golint@latest
-RUN go install golang.org/x/tools/cmd/goimports@latest
-RUN go install github.com/incu6us/goimports-reviser/v3@latest
+# need to pin goimports and goimports-reviser version to go 1.22 specific versions
+RUN go install golang.org/x/tools/cmd/goimports@v0.30.0
+RUN go install github.com/incu6us/goimports-reviser/v3@v3.8.2
 RUN export K8S_VERSION=1.24.2 && \
     curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)" && \
     mkdir /usr/local/kubebuilder && \


### PR DESCRIPTION
pin versions of goimports and goimports-reviser modules to go 1.22 co…mpatible versions

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently backports to v1.4 are broken due to missing / incorrect package versions. 

The PR addresses these so subsequent backport PRs can pass CI.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
