### PR TITLE
Fix bug in bindDeviceToOriginalDriver

### DIFF
--- a/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
+++ b/pkg/controller/pcideviceclaim/pcideviceclaim_controller.go
@@ -588,6 +588,11 @@ func (h *Handler) bindDeviceToOriginalDriver(pd *v1beta1.PCIDevice) error {
 		return nil
 	}
 
+	orgDriverPath := "/sys/bus/pci/drivers/" + orgDriver
+	if deviceBoundToDriver(orgDriverPath, address) {
+		return nil
+	}
+
 	logrus.Debugf("Binding device %s [%s] to %s", pd.Name, address, orgDriver)
 	file, err := os.OpenFile(fmt.Sprintf("/sys/bus/pci/drivers/%s/bind", orgDriver), os.O_WRONLY, 0200)
 	if err != nil {


### PR DESCRIPTION
**Problem:**
A pcideviceclaim CR is created, but kernel fails to load vfio-pci driver for some reason.
Thus, the pcideviceclaim controller always re-enqueue the CR and try to load vfio-pci driver.
When we try to delete the pcideviceclaim CR, controller fails and print message "Error writing to bind file: write /sys/bus/pci/drivers/bnx2x/bind: no such device".
The failing reason is that controller try to bind device to its original driver when deleting pcideviceclaim. However the device is binded to that driver.

**Solution:**
Check device driver before bind device to original driver

**Related Issue:**
https://github.com/harvester/harvester/issues/8951

**Test plan:**
1. kernel fails to load vfio-pci driver
2. create a pcideviceclaim CR
3. try to delete the pcideviceclaim CR, should be deleted successfully