### PR TITLE
fix up ci failures due to upstream bump of goimports package

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,7 +7,7 @@ RUN zypper -n ar  https://download.opensuse.org/repositories/hardware/15.6/hardw
     zypper -n --gpg-auto-import-keys refresh && \
     zypper -n install bash git gcc docker vim less file curl wget ca-certificates pciutils umockdev awk jq
 RUN go install golang.org/x/lint/golint@latest
-RUN go install golang.org/x/tools/cmd/goimports@latest
+RUN go install golang.org/x/tools/cmd/goimports@v0.36.0
 RUN go install github.com/incu6us/goimports-reviser/v3@v3.8.2
 RUN export K8S_VERSION=1.24.2 && \
     curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)" && \


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR drops goimports version to v0.36.0, as current latest is v0.37.0 which needs go version 1.24

pcidevices will not be bumped to go v1.24 hence the bump down to a lower pinned version.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
