### PR TITLE
fix up cleanup of pcidevice resources on node cleanup

### DIFF
--- a/pkg/webhook/indexer.go
+++ b/pkg/webhook/indexer.go
@@ -62,12 +62,17 @@ func usbDeviceClaimByAddress(obj *v1beta1.USBDeviceClaim) ([]string, error) {
 
 // isNodeDeleted checks if nodeObject exists
 func isNodeDeleted(nodeCache ctlcorev1.NodeCache, nodeName string) (bool, error) {
-	_, err := nodeCache.Get(nodeName)
-	if err == nil {
-		return false, nil
+	nodeObj, err := nodeCache.Get(nodeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// node object does not exist
+			return true, nil
+		}
+		return false, err
 	}
-	if apierrors.IsNotFound(err) {
-		// node object does not exist
+
+	// node can be ignored to allow cleanup of resources
+	if !nodeObj.DeletionTimestamp.IsZero() {
 		return true, nil
 	}
 	return false, err


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR https://github.com/harvester/pcidevices/pull/146 introduced logic to cleanup pcidevice resources when a node is deleted.

The cleanup is triggered when node has a deletiontimestamp set. The webhook checks `isNodeDeleted` which only returns true when node  object is not found. This can cause actual deletion of resources to be blocked by the webhook.

For example on deleted node in a cluster

```
harvester-pcidevices-controller-2nrfz agent time="2025-10-01T06:16:54Z" level=error msg="error syncing 'hp-69-tink-system': handler node-remove: admission webhook \"pcidevices.harvesterhci.io\" denied the request: usbdevice hp-69-tink-system-8087-8002-005002 is still in use, requeuing"
harvester-pcidevices-controller-2nrfz agent time="2025-10-01T06:17:54Z" level=error msg="error deleting device hp-69-tink-system-8087-8002-005002: admission webhook \"pcidevices.harvesterhci.io\" denied the request: usbdevice hp-69-tink-system-8087-8002-005002 is still in use"
harvester-pcidevices-controller-2nrfz agent time="2025-10-01T06:17:54Z" level=error msg="error syncing 'hp-69-tink-system': handler node-remove: admission webhook \"pcidevices.harvesterhci.io\" denied the request: usbdevice hp-69-tink-system-8087-8002-005002 is still in use, requeuing"
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Minor change to `isNodeDeleted` method to return true if node has deletionTimestamp set.

**Related Issue:**
https://github.com/harvester/harvester/issues/7400

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
