### PR TITLE
fix parent sriovgpudevice label on PCIdevice object

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -29,7 +29,7 @@ RUN export K8S_VERSION=v1.34.0 && \
     tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
 
 ## install golangci
-#RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
 ENV GO111MODULE=on
 ENV DAPPER_ENV="REPO TAG DRONE_TAG"

--- a/pkg/controller/gpudevice/vgpu_controller.go
+++ b/pkg/controller/gpudevice/vgpu_controller.go
@@ -122,10 +122,10 @@ func (h *Handler) reconcileVGPUSetup(vGPUDevices []*v1beta1.VGPUDevice) error {
 			return fmt.Errorf("error looking up PCIDevice %s as part of vGPUDevice: %w", v.Name, err)
 		}
 		pciDeviceObjCopy := pciDeviceObj.DeepCopy()
-		if pciDeviceObjCopy.Annotations == nil {
-			pciDeviceObjCopy.Annotations = make(map[string]string)
+		if pciDeviceObjCopy.Labels == nil {
+			pciDeviceObjCopy.Labels = make(map[string]string)
 		}
-		pciDeviceObjCopy.Labels[v1beta1.ParentSRIOVGPUDeviceLabel] = v1beta1.PCIDeviceNameForHostname(v.Spec.Address, h.nodeName)
+		pciDeviceObjCopy.Labels[v1beta1.ParentSRIOVGPUDeviceLabel] = v.Labels[v1beta1.ParentSRIOVGPUDeviceLabel]
 		if !reflect.DeepEqual(pciDeviceObjCopy, pciDeviceObj) {
 			if _, err := h.pciDevice.Update(pciDeviceObjCopy); err != nil {
 				return fmt.Errorf("error applying label %s to pcidevice %s during vGPU setup: %w", v1beta1.ParentSRIOVGPUDeviceLabel, v.Name, err)


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR https://github.com/harvester/pcidevices/pull/165 added additional logic in vGPUdevice setup, to add the parent SRIOVGPUDevice name as a label to the PCIDevice. This is needed to ensure that the UI can easily filter PCIDevices which are owned by a specific SRIOVGPUDevice.

The label value being added was wrong, and was the vGPUDevice name when it needed to be the parent SRIOVGPUDevice.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR fixes the correct parent SRIOVGPUDevice label value and also enables golint-ci installation in dapper builds.

**Related Issue:**
https://github.com/harvester/harvester/issues/10120#issuecomment-4159206317

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
