### PR TITLE
feat: validate vgpu device because vgpu device is moved to hostdevice…

### DIFF
--- a/pkg/webhook/vm_validataion_test.go
+++ b/pkg/webhook/vm_validataion_test.go
@@ -147,7 +147,7 @@ func Test_CreateVM(t *testing.T) {
 			before: func(in input) {
 				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].DeviceName = "fake.com/device2"
 			},
-			err: errors.New("hostdevice usbdevice2innode1: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
+			err: errors.New("hostdevice usbdevice2innode1: resource name fake.com/device2 not found in pcidevice, usbdevice, and vgpu device cache"),
 		},
 		{
 			name: "pci device name is different from CR, it should be able to create",
@@ -161,7 +161,7 @@ func Test_CreateVM(t *testing.T) {
 			before: func(in input) {
 				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].DeviceName = "fake.com/device2"
 			},
-			err: errors.New("hostdevice node1dev1noiommu: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
+			err: errors.New("hostdevice node1dev1noiommu: resource name fake.com/device2 not found in pcidevice, usbdevice, and vgpu device cache"),
 		},
 	}
 
@@ -243,7 +243,7 @@ func Test_UpdateVM(t *testing.T) {
 			before: func(in input) {
 				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[0].DeviceName = "fake.com/device2"
 			},
-			err: errors.New("hostdevice usbdevice2innode1: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
+			err: errors.New("hostdevice usbdevice2innode1: resource name fake.com/device2 not found in pcidevice, usbdevice, and vgpu device cache"),
 		},
 		{
 			name: "pci device name is different from CR, it should be able to create",
@@ -257,7 +257,7 @@ func Test_UpdateVM(t *testing.T) {
 			before: func(in input) {
 				in.vm.Spec.Template.Spec.Domain.Devices.HostDevices[1].DeviceName = "fake.com/device2"
 			},
-			err: errors.New("hostdevice node1dev1noiommu: resource name fake.com/device2 not found in pcidevice and usbdevice cache"),
+			err: errors.New("hostdevice node1dev1noiommu: resource name fake.com/device2 not found in pcidevice, usbdevice, and vgpu device cache"),
 		},
 	}
 
@@ -279,5 +279,72 @@ func Test_UpdateVM(t *testing.T) {
 		err := validator.Update(nil, nil, in.vm)
 
 		assert.Equal(t, tc.err, err, tc.name)
+	}
+}
+
+func Test_validatevGPUDvice(t *testing.T) {
+	vgpuDevice := &devicesv1beta1.VGPUDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vgpu-test-device",
+		},
+		Spec: devicesv1beta1.VGPUDeviceSpec{
+			Address:                "0000:08:00.5",
+			Enabled:                true,
+			NodeName:               "test-node",
+			ParentGPUDeviceAddress: "0000:08:00.0",
+			VGPUTypeName:           "NVIDIA A2-2Q",
+		},
+		Status: devicesv1beta1.VGPUDeviceStatus{
+			ConfiguredVGPUTypeName: "NVIDIA A2-2Q",
+			UUID:                   "f2285cf1-0aaa-4d05-af20-78cec22f02c7",
+			VGPUStatus:             "vGPUConfigured",
+		},
+	}
+
+	testcases := []struct {
+		name         string
+		resourceName string
+		expectedErr  error
+		expectedFind bool
+	}{
+		{
+			name:         "vGPU device found with matching resource name",
+			resourceName: "nvidia.com/NVIDIA_A2-2Q",
+			expectedErr:  nil,
+			expectedFind: true,
+		},
+		{
+			name:         "vGPU device not found with non-matching resource name",
+			resourceName: "nvidia.com/NVIDIA_A2-4Q",
+			expectedErr:  nil,
+			expectedFind: false,
+		},
+		{
+			name:         "vGPU device not found with completely different resource name",
+			resourceName: "fake.com/device1",
+			expectedErr:  nil,
+			expectedFind: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(vgpuDevice)
+			vGPUCache := fakeclients.VGPUDeviceCache(fakeClient.DevicesV1beta1().VGPUDevices)
+
+			validator := &vmDeviceHostValidator{
+				vgpuCache: vGPUCache,
+			}
+
+			found, err := validator.validatevGPUDvice(tc.resourceName)
+
+			if tc.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedFind, found)
+		})
 	}
 }

--- a/pkg/webhook/vm_validatation.go
+++ b/pkg/webhook/vm_validatation.go
@@ -57,6 +57,8 @@ func (vmValidator *vmDeviceHostValidator) validateDevices(vmObj *kubevirtv1.Virt
 	logrus.Infof("vm name: %s", vmObj.Name)
 	logrus.Infof("host devices: %v", vmObj.Spec.Template.Spec.Domain.Devices.HostDevices)
 	logrus.Infof("gpu devices: %v", vmObj.Spec.Template.Spec.Domain.Devices.GPUs)
+	
+	// Validate HostDevices
 	if len(vmObj.Spec.Template.Spec.Domain.Devices.HostDevices) != 0 {
 		if err := vmValidator.validateHostDevices(vmObj); err != nil {
 			return err
@@ -65,6 +67,14 @@ func (vmValidator *vmDeviceHostValidator) validateDevices(vmObj *kubevirtv1.Virt
 			return err
 		}
 	}
+	
+	// Also validate GPUs if they exist (in case mutator hasn't run yet)
+	if len(vmObj.Spec.Template.Spec.Domain.Devices.GPUs) != 0 {
+		if err := vmValidator.validateGPUDevices(vmObj); err != nil {
+			return err
+		}
+	}
+	
 	return nil
 }
 
@@ -115,9 +125,13 @@ func (vmValidator *vmDeviceHostValidator) validateDevicesFromSameNodes(vmObj *ku
 func (vmValidator *vmDeviceHostValidator) validateHostDevices(vmObj *kubevirtv1.VirtualMachine) error {
 	for _, hostDevice := range vmObj.Spec.Template.Spec.Domain.Devices.HostDevices {
 		var (
-			foundInPCI, foundInUSB bool
-			err                    error
+			foundInPCI, foundInUSB, foundInvGPU bool
+			err                                 error
 		)
+
+		if foundInvGPU, err = vmValidator.validatevGPUDvice(hostDevice.DeviceName); err != nil {
+			return err
+		}
 
 		if foundInPCI, err = vmValidator.validatePCIDevice(hostDevice.DeviceName); err != nil {
 			return err
@@ -127,11 +141,24 @@ func (vmValidator *vmDeviceHostValidator) validateHostDevices(vmObj *kubevirtv1.
 			return err
 		}
 
-		if !foundInPCI && !foundInUSB {
-			return fmt.Errorf("hostdevice %s: resource name %s not found in pcidevice and usbdevice cache", hostDevice.Name, hostDevice.DeviceName)
+		if !foundInPCI && !foundInUSB && !foundInvGPU {
+			return fmt.Errorf("hostdevice %s: resource name %s not found in pcidevice, usbdevice, and vgpu device cache", hostDevice.Name, hostDevice.DeviceName)
 		}
 	}
 	return nil
+}
+
+func (vmValidator *vmDeviceHostValidator) validatevGPUDvice(resourceName string) (found bool, err error) {
+	vgpuDeviceObjs, err := vmValidator.vgpuCache.GetByIndex(vGPUDeviceByResourceName, resourceName)
+	if err != nil {
+		return false, fmt.Errorf("error looking up vgpu device %s from cache: %v", resourceName, err)
+	}
+
+	if len(vgpuDeviceObjs) == 0 {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (vmValidator *vmDeviceHostValidator) validatePCIDevice(resourceName string) (found bool, err error) {
@@ -158,4 +185,19 @@ func (vmValidator *vmDeviceHostValidator) validateUSBDevice(resourceName string)
 	}
 
 	return true, nil
+}
+
+func (vmValidator *vmDeviceHostValidator) validateGPUDevices(vmObj *kubevirtv1.VirtualMachine) error {
+	for _, gpu := range vmObj.Spec.Template.Spec.Domain.Devices.GPUs {
+		// DeviceName in GPU spec maps to generated ResourceName advertised by the plugin
+		found, err := vmValidator.validatevGPUDvice(gpu.DeviceName)
+		if err != nil {
+			return err
+		}
+
+		if !found {
+			return fmt.Errorf("gpu device %s: resource name %s not found in vgpu device cache", gpu.Name, gpu.DeviceName)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
because vm.spec.vgpu is moved to vm.spec.hostdevices, we should also use vgpu cache to check that.

**Solution:**
Use vgpu cache to check the resource.

**Related Issue:**
https://github.com/harvester/harvester/issues/10394#top

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
