### PR TITLE
fix vgpu status reconcile after reboots and upgrades

### DIFF
--- a/pkg/controller/gpudevice/vgpu_controller.go
+++ b/pkg/controller/gpudevice/vgpu_controller.go
@@ -77,11 +77,16 @@ func (h *Handler) reconcileVGPUSetup(vGPUDevices []*v1beta1.VGPUDevice) error {
 	for _, v := range vGPUDevices {
 		existingVGPU := containsVGPU(v, vGPUList)
 		if existingVGPU != nil {
-			if v.Status.VGPUStatus != existingVGPU.Status.VGPUStatus {
+			logrus.Debugf("found vGPU device from sysfs with address %s and name %s and status %v", v.Spec.Address, v.Name, v.Status)
+			logrus.Debugf("found vGPU device from apiserver with address %s and name %s and status %v", existingVGPU.Spec.Address, existingVGPU.Name, existingVGPU.Status)
+			existingVGPUCopy := existingVGPU.DeepCopy()
+			existingVGPU.Status.AvailableTypes = v.Status.AvailableTypes
+			existingVGPU.Status.VGPUStatus = v.Status.VGPUStatus
+			existingVGPU.Status.UUID = v.Status.UUID
+			if !reflect.DeepEqual(existingVGPUCopy.Status, existingVGPU.Status) {
 				// on reboot the vGPU status will not match the state in CRD
 				// in which case we should if needed reset the vGPU status and
 				// allow reconcile to flow through
-				existingVGPU.Status.VGPUStatus = v.Status.VGPUStatus
 				if _, err := h.vGPUClient.UpdateStatus(existingVGPU); err != nil {
 					return err
 				}


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
vgpu device cannot be enabled after upgrade as the vgpu type is not valid as per status
```
hp-130-tink-system-000008006': handler on-vgpu-change: VGPUType specified NVIDIA A2-2A is not available for vGPU 0000:08:00.6 
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
change logic for vgpu status update in reconcileVGPUSetup, to allow s…ysfs status to be updated to k8s object to ensure device gets re-enabled after upgrades and reboots


**Related Issue:**
https://github.com/harvester/harvester/issues/10394#top

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->