### PR TITLE
changes to pcidevices webhook to check if a pcidevice is being used as a parent device for vgpu's 

### DIFF
--- a/pkg/util/fakeclients/pcidevices.go
+++ b/pkg/util/fakeclients/pcidevices.go
@@ -66,8 +66,16 @@ func (p PCIDevicesCache) Get(name string) (*pcidevicev1beta1.PCIDevice, error) {
 	return p().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (p PCIDevicesCache) List(labels.Selector) ([]*pcidevicev1beta1.PCIDevice, error) {
-	panic("implement me")
+func (p PCIDevicesCache) List(selector labels.Selector) ([]*pcidevicev1beta1.PCIDevice, error) {
+	devices, err := p().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	var resp []*pcidevicev1beta1.PCIDevice
+	for i := range devices.Items {
+		resp = append(resp, &devices.Items[i])
+	}
+	return resp, nil
 }
 
 func (p PCIDevicesCache) AddIndexer(_ string, _ generic.Indexer[*pcidevicev1beta1.PCIDevice]) {

--- a/pkg/webhook/pcideviceclaim.go
+++ b/pkg/webhook/pcideviceclaim.go
@@ -7,6 +7,7 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kubevirtctl "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
@@ -89,6 +90,23 @@ func (pdc *pciDeviceClaimValidator) Create(_ *types.Request, newObj runtime.Obje
 		return err
 	}
 
+	// check if vGPU devices exist for associated PCIDevice, and block creation of PCIDeviceClaim if there are vGPU devices using the same PCIDevice
+	childDevices, err := pdc.deviceCache.List(labels.SelectorFromSet(labels.Set{devicesv1beta1.ParentSRIOVGPUDeviceLabel: pciDev.Name}))
+	if err != nil {
+		return err
+	}
+
+	if len(childDevices) != 0 {
+		var used []string
+		for _, childDev := range childDevices {
+			used = append(used, childDev.Name)
+		}
+
+		vgpuDevices := strings.Join(used, ", ")
+		err = fmt.Errorf("these vGPU devices [%s] are using the PCI GPU Device [%s], so it can't be claimed. \n If you need to claim this PCI GPU device, please disable associated SRIOVGPUDevice", vgpuDevices, pciDev.Name)
+		logrus.Error(err.Error())
+		return err
+	}
 	return nil
 }
 

--- a/pkg/webhook/pcideviceclaim_test.go
+++ b/pkg/webhook/pcideviceclaim_test.go
@@ -60,6 +60,54 @@ var (
 			Name: "node1",
 		},
 	}
+
+	parentGPU = &devicesv1beta1.PCIDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1gpu1",
+		},
+		Spec: devicesv1beta1.PCIDeviceSpec{},
+		Status: devicesv1beta1.PCIDeviceStatus{
+			Address:           "0000:04:10.0",
+			ClassID:           "0300",
+			Description:       "fake GPU device 1",
+			NodeName:          "node1",
+			ResourceName:      "fake.com/gpudevice1",
+			VendorID:          "8086",
+			KernelDriverInUse: "vfio-pci",
+			IOMMUGroup:        "15",
+		},
+	}
+	vGPUDevice = &devicesv1beta1.PCIDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1vgpu1",
+			Labels: map[string]string{
+				devicesv1beta1.ParentSRIOVGPUDeviceLabel: "node1gpu1",
+			},
+		},
+		Spec: devicesv1beta1.PCIDeviceSpec{},
+		Status: devicesv1beta1.PCIDeviceStatus{
+			Address:           "0000:04:10.1",
+			ClassID:           "0300",
+			Description:       "fake vGPU device 1",
+			NodeName:          "node1",
+			ResourceName:      "fake.com/vgpudevice1",
+			VendorID:          "8086",
+			KernelDriverInUse: "vfio-pci",
+			IOMMUGroup:        "15",
+		},
+	}
+
+	parentGPUClaim = &devicesv1beta1.PCIDeviceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1gpu1",
+		},
+		Spec: devicesv1beta1.PCIDeviceClaimSpec{
+			UserName: "admin",
+			NodeName: "node1",
+			Address:  "0000:04:10.0",
+		},
+	}
+
 	k8sClient = k8sfake.NewClientset(node1)
 	nodeCache = fakeclients.NodeCache(k8sClient.CoreV1().Nodes)
 )
@@ -147,4 +195,15 @@ func Test_DeletePCIDeviceClaimInUseOnDeletedNode(t *testing.T) {
 
 	err := pciValidator.Delete(nil, node2dev1Claim)
 	assert.NoError(err, "expected no error during validation")
+}
+
+func Test_CreatePCIDeviceClaimWhenVGPUExist(t *testing.T) {
+	assert := require.New(t)
+	fakeClient := fake.NewSimpleClientset(vGPUDevice, parentGPU)
+	pciDeviceCache := fakeclients.PCIDevicesCache(fakeClient.DevicesV1beta1().PCIDevices)
+	usbDeviceClaimCache := fakeclients.USBDeviceClaimsCache(fakeClient.DevicesV1beta1().USBDeviceClaims)
+	usbDeviceCache := fakeclients.USBDeviceCache(fakeClient.DevicesV1beta1().USBDevices)
+	pciValidator := NewPCIDeviceClaimValidator(pciDeviceCache, nil, usbDeviceClaimCache, usbDeviceCache, nodeCache)
+	err := pciValidator.Create(nil, parentGPUClaim)
+	assert.Error(err, "expected to get error")
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
We need to block users from accidentally creating a PCIDeviceClaim for a PCIDevice which may be in use as a parent device for vGPUDevices.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Minor changes to harvester-webhook to check if a PCIDevice is being used as a parent for vGPU's.

In case the PCIDevice is the parent device for vGPUdevices then the webhook will block the creation of a PCIDeviceClaim associated with the PCIDevice.

**Related Issue:**
https://github.com/harvester/harvester/issues/10428

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
