### PR TITLE
feat: add identifying usb device class

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -34,7 +34,7 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 ENV GO111MODULE=on
 ENV DAPPER_ENV="REPO TAG DRONE_TAG"
 ENV DAPPER_SOURCE="/go/src/github.com/harvester/pcidevices/"
-ENV DAPPER_OUTPUT="./bin ./dist ./pkg"
+ENV DAPPER_OUTPUT="./bin ./dist ./pkg ./charts"
 ENV DAPPER_RUN_ARGS="-v /proc:/host/proc --privileged"
 ENV DAPPER_DOCKER_SOCKET=true
 ENV HOME=${DAPPER_SOURCE}

--- a/charts/templates/crds.yaml
+++ b/charts/templates/crds.yaml
@@ -406,6 +406,9 @@ spec:
         properties:
           status:
             properties:
+              classType:
+                nullable: true
+                type: string
               description:
                 nullable: true
                 type: string
@@ -993,6 +996,9 @@ spec:
       properties:
         status:
           properties:
+            classType:
+              nullable: true
+              type: string
             description:
               nullable: true
               type: string

--- a/pkg/apis/devices.harvesterhci.io/v1beta1/usb_device.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/usb_device.go
@@ -24,6 +24,7 @@ type USBDeviceStatus struct {
 	DevicePath   string `json:"devicePath"`
 	Description  string `json:"description"`
 	PCIAddress   string `json:"pciAddress"`
+	ClassType    string `json:"classType,omitempty"`
 	Enabled      bool   `json:"enabled"`
 	Status       string `json:"status,omitempty"`
 	Message      string `json:"message,omitempty"`

--- a/pkg/controller/usbdevice/usbdevice_controller.go
+++ b/pkg/controller/usbdevice/usbdevice_controller.go
@@ -259,6 +259,7 @@ func (h *DevHandler) getList(localUSBDevices map[int][]*deviceplugins.USBDevice,
 						DevicePath:   localUSBDevice.DevicePath,
 						Description:  usbid.DescribeWithVendorAndProduct(gousb.ID(localUSBDevice.Vendor), gousb.ID(localUSBDevice.Product)), // nolint:gosec
 						PCIAddress:   localUSBDevice.PCIAddress,
+						ClassType:    localUSBDevice.ClassType,
 					},
 				}
 				createList = append(createList, createdOne)
@@ -273,6 +274,7 @@ func (h *DevHandler) getList(localUSBDevices map[int][]*deviceplugins.USBDevice,
 						DevicePath:   localUSBDevice.DevicePath,
 						Description:  usbid.DescribeWithVendorAndProduct(gousb.ID(localUSBDevice.Vendor), gousb.ID(localUSBDevice.Product)), // nolint:gosec
 						PCIAddress:   localUSBDevice.PCIAddress,
+						ClassType:    localUSBDevice.ClassType,
 					}
 					updateList = append(updateList, existedCp)
 				}

--- a/pkg/controller/usbdevice/usbdevice_controller.go
+++ b/pkg/controller/usbdevice/usbdevice_controller.go
@@ -257,7 +257,7 @@ func (h *DevHandler) getList(localUSBDevices map[int][]*deviceplugins.USBDevice,
 						ResourceName: resourceName(name),
 						NodeName:     nodeName,
 						DevicePath:   localUSBDevice.DevicePath,
-						Description:  usbid.DescribeWithVendorAndProduct(gousb.ID(localUSBDevice.Vendor), gousb.ID(localUSBDevice.Product)), // nolint:gosec
+						Description:  usbDescription(localUSBDevice),
 						PCIAddress:   localUSBDevice.PCIAddress,
 						ClassType:    localUSBDevice.ClassType,
 					},
@@ -272,7 +272,7 @@ func (h *DevHandler) getList(localUSBDevices map[int][]*deviceplugins.USBDevice,
 						ResourceName: resourceName(usbDeviceName(nodeName, localUSBDevice)),
 						NodeName:     nodeName,
 						DevicePath:   localUSBDevice.DevicePath,
-						Description:  usbid.DescribeWithVendorAndProduct(gousb.ID(localUSBDevice.Vendor), gousb.ID(localUSBDevice.Product)), // nolint:gosec
+						Description:  usbDescription(localUSBDevice),
 						PCIAddress:   localUSBDevice.PCIAddress,
 						ClassType:    localUSBDevice.ClassType,
 					}
@@ -321,6 +321,19 @@ func isStatusChanged(existed *v1beta1.USBDevice, localUSBDevice *deviceplugins.U
 
 func resourceName(name string) string {
 	return fmt.Sprintf("%s%s", KubeVirtResourcePrefix, name)
+}
+
+// usbDescription builds the device description string from the usbid lookup,
+// appending the sysfs product name when available.
+// e.g. "Kingston Technology HyperX Alloy FPS Mechanical Gaming Keyboard" or
+//
+//	"Kingston Technology (0x0951) HyperX Alloy FPS [HyperX Alloy FPS]"
+func usbDescription(d *deviceplugins.USBDevice) string {
+	desc := usbid.DescribeWithVendorAndProduct(gousb.ID(d.Vendor), gousb.ID(d.Product)) // nolint:gosec
+	if d.ProductName != "" {
+		desc = fmt.Sprintf("%s [%s]", desc, d.ProductName)
+	}
+	return desc
 }
 
 func isCreateEvent(op fsnotify.Op) bool {

--- a/pkg/deviceplugins/usb_device_plugin_helper.go
+++ b/pkg/deviceplugins/usb_device_plugin_helper.go
@@ -71,18 +71,30 @@ type USBDevice struct {
 	DevicePath   string
 	PCIAddress   string
 	ClassType    string
+	ProductName  string
 }
 
 func (dev *USBDevice) GetID() string {
 	return fmt.Sprintf("%04x:%04x-%02d:%02d", dev.Vendor, dev.Product, dev.Bus, dev.DeviceNumber)
 }
 
+// readSysfsString reads a plain-text sysfs file (e.g. "product", "manufacturer")
+// and returns its trimmed content, or an empty string on error.
+func readSysfsString(dir, filename string) string {
+	data, err := os.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(data))
+}
+
 // parseClassCode reads a sysfs file containing a hex USB class code (e.g. "bDeviceClass")
 // and returns the parsed integer value.
 // Returns (0, false) on any read or parse error.
 func parseClassCode(dir, filename string) (int, bool) {
-	data, err := os.ReadFile(filepath.Join(dir, filename))
-	if err != nil {
+	data := readSysfsString(dir, filename)
+	if data == "" {
 		return 0, false
 	}
 
@@ -93,6 +105,7 @@ func parseClassCode(dir, filename string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
+
 	return int(code), true
 }
 
@@ -124,16 +137,17 @@ func parseUSBClassType(path string) string {
 	if err != nil {
 		return ""
 	}
+
 	for _, entry := range entries {
 		if !entry.IsDir() || !strings.Contains(entry.Name(), ":") {
 			continue
 		}
 
-		path := filepath.Join(path, entry.Name())
-		if iCode, ok := parseClassCode(path, "bInterfaceClass"); ok {
+		if iCode, ok := parseClassCode(filepath.Join(path, entry.Name()), "bInterfaceClass"); ok {
 			return classTypeName(iCode)
 		}
 	}
+
 	return ""
 }
 
@@ -170,6 +184,7 @@ func parseSysUeventFile(path string) *USBDevice {
 		}
 	}
 
+	u.ProductName = readSysfsString(path, "product")
 	u.ClassType = parseUSBClassType(path)
 
 	return &u

--- a/pkg/deviceplugins/usb_device_plugin_helper.go
+++ b/pkg/deviceplugins/usb_device_plugin_helper.go
@@ -30,6 +30,35 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// usbClassNames maps USB base class codes (from https://www.usb.org/defined-class-codes)
+// to human-readable names.
+var usbClassNames = map[int]string{
+	0x01: "Audio",
+	0x02: "Communications",
+	0x03: "HID",
+	0x05: "Physical",
+	0x06: "Image",
+	0x07: "Printer",
+	0x08: "Mass Storage",
+	0x09: "Hub",
+	0x0A: "CDC-Data",
+	0x0B: "Smart Card",
+	0x0D: "Content Security",
+	0x0E: "Video",
+	0x0F: "Personal Healthcare",
+	0x10: "Audio/Video",
+	0x11: "Billboard",
+	0x12: "USB Type-C Bridge",
+	0x13: "USB Bulk Display Protocol",
+	0x14: "MCTP over USB",
+	0x3C: "I3C Device",
+	0xDC: "Diagnostic",
+	0xE0: "Wireless Controller",
+	0xEF: "Miscellaneous",
+	0xFE: "Application Specific",
+	0xFF: "Vendor Specific",
+}
+
 type USBDevice struct {
 	Name         string
 	Manufacturer string
@@ -41,10 +70,71 @@ type USBDevice struct {
 	Serial       string
 	DevicePath   string
 	PCIAddress   string
+	ClassType    string
 }
 
 func (dev *USBDevice) GetID() string {
 	return fmt.Sprintf("%04x:%04x-%02d:%02d", dev.Vendor, dev.Product, dev.Bus, dev.DeviceNumber)
+}
+
+// parseClassCode reads a sysfs file containing a hex USB class code (e.g. "bDeviceClass")
+// and returns the parsed integer value.
+// Returns (0, false) on any read or parse error.
+func parseClassCode(dir, filename string) (int, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		return 0, false
+	}
+
+	// Convert the sysfs hex string to a decimal integer, then look it up in usbClassNames.
+	// e.g. "09" (hex string) → 9 (decimal int) → usbClassNames[9] = "Hub"
+	//      "ff" (hex string) → 255 (decimal int) → usbClassNames[255] = "Vendor Specific"
+	code, err := strconv.ParseInt(strings.TrimSpace(string(data)), 16, 32)
+	if err != nil {
+		return 0, false
+	}
+	return int(code), true
+}
+
+// classTypeName returns the human-readable name for a USB class code,
+// falling back to "Unknown (0xNN)" if the code is not in the map.
+func classTypeName(code int) string {
+	if name, ok := usbClassNames[code]; ok {
+		return name
+	}
+	return fmt.Sprintf("Unknown (0x%02x)", code)
+}
+
+// parseUSBClassType determines the USB class name for a device rooted at path.
+// When bDeviceClass is 00, the class is reported per-interface; in that case the
+// function reads bInterfaceClass from the first interface sub-directory.
+func parseUSBClassType(path string) string {
+	code, ok := parseClassCode(path, "bDeviceClass")
+	if !ok {
+		logrus.Debugf("Unable to read or parse bDeviceClass from %s", path)
+		return ""
+	}
+
+	if code != 0 {
+		return classTypeName(code)
+	}
+
+	// class 00 means "use Interface Descriptors" – look at the first interface sub-directory
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.Contains(entry.Name(), ":") {
+			continue
+		}
+
+		path := filepath.Join(path, entry.Name())
+		if iCode, ok := parseClassCode(path, "bInterfaceClass"); ok {
+			return classTypeName(iCode)
+		}
+	}
+	return ""
 }
 
 func parseSysUeventFile(path string) *USBDevice {
@@ -79,6 +169,8 @@ func parseSysUeventFile(path string) *USBDevice {
 			return nil
 		}
 	}
+
+	u.ClassType = parseUSBClassType(path)
 
 	return &u
 }

--- a/pkg/deviceplugins/usb_device_plugin_helper.go
+++ b/pkg/deviceplugins/usb_device_plugin_helper.go
@@ -31,32 +31,32 @@ import (
 )
 
 // usbClassNames maps USB base class codes (from https://www.usb.org/defined-class-codes)
-// to human-readable names.
-var usbClassNames = map[int]string{
-	0x01: "Audio",
-	0x02: "Communications",
-	0x03: "HID",
-	0x05: "Physical",
-	0x06: "Image",
-	0x07: "Printer",
-	0x08: "Mass Storage",
-	0x09: "Hub",
-	0x0A: "CDC-Data",
-	0x0B: "Smart Card",
-	0x0D: "Content Security",
-	0x0E: "Video",
-	0x0F: "Personal Healthcare",
-	0x10: "Audio/Video",
-	0x11: "Billboard",
-	0x12: "USB Type-C Bridge",
-	0x13: "USB Bulk Display Protocol",
-	0x14: "MCTP over USB",
-	0x3C: "I3C Device",
-	0xDC: "Diagnostic",
-	0xE0: "Wireless Controller",
-	0xEF: "Miscellaneous",
-	0xFE: "Application Specific",
-	0xFF: "Vendor Specific",
+// to human-readable names. Keys are lowercase hex strings as read from sysfs.
+var usbClassNames = map[string]string{
+	"01": "Audio",
+	"02": "Communications",
+	"03": "HID",
+	"05": "Physical",
+	"06": "Image",
+	"07": "Printer",
+	"08": "Mass Storage",
+	"09": "Hub",
+	"0a": "CDC-Data",
+	"0b": "Smart Card",
+	"0d": "Content Security",
+	"0e": "Video",
+	"0f": "Personal Healthcare",
+	"10": "Audio/Video",
+	"11": "Billboard",
+	"12": "USB Type-C Bridge",
+	"13": "USB Bulk Display Protocol",
+	"14": "MCTP over USB",
+	"3c": "I3C Device",
+	"dc": "Diagnostic",
+	"e0": "Wireless Controller",
+	"ef": "Miscellaneous",
+	"fe": "Application Specific",
+	"ff": "Vendor Specific",
 }
 
 type USBDevice struct {
@@ -90,32 +90,24 @@ func readSysfsString(dir, filename string) string {
 }
 
 // parseClassCode reads a sysfs file containing a hex USB class code (e.g. "bDeviceClass")
-// and returns the parsed integer value.
-// Returns (0, false) on any read or parse error.
-func parseClassCode(dir, filename string) (int, bool) {
+// and returns the lowercase string value as-is (e.g. "09", "ff").
+// Returns ("", false) on any read error.
+func parseClassCode(dir, filename string) (string, bool) {
 	data := readSysfsString(dir, filename)
 	if data == "" {
-		return 0, false
+		return "", false
 	}
 
-	// Convert the sysfs hex string to a decimal integer, then look it up in usbClassNames.
-	// e.g. "09" (hex string) → 9 (decimal int) → usbClassNames[9] = "Hub"
-	//      "ff" (hex string) → 255 (decimal int) → usbClassNames[255] = "Vendor Specific"
-	code, err := strconv.ParseInt(strings.TrimSpace(string(data)), 16, 32)
-	if err != nil {
-		return 0, false
-	}
-
-	return int(code), true
+	return strings.ToLower(data), true
 }
 
 // classTypeName returns the human-readable name for a USB class code,
 // falling back to "Unknown (0xNN)" if the code is not in the map.
-func classTypeName(code int) string {
+func classTypeName(code string) string {
 	if name, ok := usbClassNames[code]; ok {
 		return name
 	}
-	return fmt.Sprintf("Unknown (0x%02x)", code)
+	return fmt.Sprintf("Unknown (0x%s)", code)
 }
 
 // parseUSBClassType determines the USB class name for a device rooted at path.
@@ -128,7 +120,7 @@ func parseUSBClassType(path string) string {
 		return ""
 	}
 
-	if code != 0 {
+	if code != "00" {
 		return classTypeName(code)
 	}
 

--- a/pkg/util/gousb/usbid/load_data.go
+++ b/pkg/util/gousb/usbid/load_data.go
@@ -27,8 +27,8 @@ import "time"
 //
 // The baked-in data was last generated:
 //
-// 2025-08-22 16:07:44.519359417 +1000 AEST m=+1.186429492
-var LastUpdate = time.Unix(0, 1755842864519359417)
+// 2026-04-29 02:38:21.56589096 +0000 UTC m=+1.293189684
+var LastUpdate = time.Unix(0, 1777430301565890960)
 
 const usbIDListData = `#
 #	List of USB ID's
@@ -41,8 +41,8 @@ const usbIDListData = `#
 #	The latest version can be obtained from
 #		http://www.linux-usb.org/usb.ids
 #
-# Version: 2025.07.26
-# Date:    2025-07-26 20:34:01
+# Version: 2025.12.13
+# Date:    2025-12-13 20:34:01
 #
 
 # Vendors, devices and interfaces. Please keep sorted.
@@ -13520,7 +13520,9 @@ const usbIDListData = `#
 0b0d  ProjectLab
 	0000  CenturyCD
 0b0e  GN Netcom
+	0301  Jabra EVOLVE 20
 	0305  Jabra EVOLVE Link MS
+	030c  Jabra EVOLVE 65
 	0311  Jabra EVOLVE 65
 	0312  enc060:Buttons Volume up/down/mute + phone [Jabra]
 	0343  Jabra UC VOICE 150a
@@ -13539,6 +13541,11 @@ const usbIDListData = `#
 	2007  GN 2000 Stereo Corded Headset
 	2456  Jabra SPEAK 810
 	245e  Jabra Link 370
+	248a  Jabra Elite 85h
+	24b8  Jabra Evolve2 65
+	24bb  Jabra Evolve2 85
+	24c9  Jabra Link 380
+	24ca  Jabra Link 380
 	620c  Jabra BT620s
 	9330  Jabra GN9330 Headset
 	a346  Jabra Engage 75 Stereo
@@ -24081,6 +24088,7 @@ C 08  Mass Storage
 		00  Control/Bulk/Interrupt
 		01  Control/Bulk
 		50  Bulk-Only
+		62  USB Attached SCSI
 C 09  Hub
 	00  Unused
 		00  Full speed (or root) hub


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
In current USB device page, we don't show the USB type on it, which users might not know what it's.

<img width="1699" height="685" alt="image" src="https://github.com/user-attachments/assets/fc90d53e-71a4-4ffc-9ba2-656bf4030a9b" />


**Solution:**
Use https://www.usb.org/defined-class-codes to identify the USB type.

If bDeviceClass is `00`
-> Look up the value of bInterfaceClass and map it to the table from the above reference.
if bDeviceClass is not `00`
-> Directly look up the value of bDeviceClass and map it to the table from the above reference.

Besides, read `product` file and append the information after the description.

```
# Example for storage device
apiVersion: devices.harvesterhci.io/v1beta1
kind: USBDevice
metadata:
  creationTimestamp: "2026-04-29T04:34:10Z"
  generation: 1
  labels:
    nodename: harvester1
  name: harvester1-0951-1666-002045
  resourceVersion: "5515884"
  uid: e1e2cf8e-b305-43df-b832-7dc48ace7822
status:
  classType: Mass Storage
  description: DataTraveler 100 G3/G4/SE9 G2/50 Kyson (Kingston Technology) [DataTraveler
    3.0]
  devicePath: /dev/bus/usb/002/045
  enabled: false
  nodeName: harvester1
  pciAddress: "0000:02:01.0"
  productID: "1666"
  resourceName: kubevirt.io/harvester1-0951-1666-002045
  vendorID: "0951"
```

**Related Issue:**
Issue: https://github.com/harvester/harvester/issues/8330
UI: https://github.com/harvester/harvester-ui-extension/pull/839

**Test plan:**

It also works to existed USB devices.

<img width="1681" height="713" alt="image" src="https://github.com/user-attachments/assets/28f32776-ce59-4fea-8271-c121afef331c" />

