### PR TITLE
fix: update existed usb device in upgrade case

### DIFF
--- a/pkg/controller/usbdevice/usbdevice_controller.go
+++ b/pkg/controller/usbdevice/usbdevice_controller.go
@@ -316,7 +316,9 @@ func usbDeviceName(nodeName string, localUSBDevice *deviceplugins.USBDevice) str
 
 func isStatusChanged(existed *v1beta1.USBDevice, localUSBDevice *deviceplugins.USBDevice) bool {
 	return existed.Status.VendorID != fmt.Sprintf("%04x", localUSBDevice.Vendor) ||
-		existed.Status.ProductID != fmt.Sprintf("%04x", localUSBDevice.Product)
+		existed.Status.ProductID != fmt.Sprintf("%04x", localUSBDevice.Product) ||
+		existed.Status.Description != usbDescription(localUSBDevice) ||
+		existed.Status.ClassType != localUSBDevice.ClassType
 }
 
 func resourceName(name string) string {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
For those exited usb devices, their description and class type aren't changed in upgrade case.

**Solution:**
if description and class type is changed, update it.

**Related Issue:**
https://github.com/harvester/harvester/issues/8330

**Test plan:**

Before:

https://github.com/user-attachments/assets/8a302d0e-3944-4686-882b-59155e9c4a46

After:

https://github.com/user-attachments/assets/5669ec1b-fce8-4310-b35b-7a3027ece1f5