### PR TITLE
Fix: Trim trailing separators from generated PCI resource names

### DIFF
--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go
@@ -111,6 +111,12 @@ func resourceName(dev *pci.Device) string {
 		productCleaned = reg.ReplaceAllString(productCleaned, "_") // Replace all spaces with underscore
 		reg, _ = regexp.Compile("[^a-zA-Z0-9_.]+")
 		productCleaned = reg.ReplaceAllString(productCleaned, "") // Removes any char other than alphanumeric and underscore
+		productCleaned = strings.TrimRight(productCleaned, "_.-") // Removes trailing non-alphanumeric separators
+
+		if productCleaned == "" {
+			productCleaned = dev.Product.ID
+		}
+
 		return trimResourceNameIfNeeded(vendorCleaned, productCleaned, dev.Product.ID)
 	}
 	// If the pcidb doesn't have the deviceId, just show the deviceId

--- a/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice_test.go
@@ -121,6 +121,40 @@ func TestDescriptionForVendorDevice(t *testing.T) {
 			want: "nvidia.com/GP106_GEFORCE_GTX_1060_3GB",
 		},
 		{
+			name: "NVIDIA RTX A4500 Embedded GPU trailing space",
+			args: args{
+				dev: &pci.Device{
+					Address: "00:1f.6",
+					Vendor: &pcidb.Vendor{
+						ID:   "10de",
+						Name: "NVIDIA Corporation",
+					},
+					Product: &pcidb.Product{
+						ID:   "24fa",
+						Name: "GA104 [RTX A4500 Embedded GPU ]",
+					},
+				},
+			},
+			want: "nvidia.com/GA104_RTX_A4500_EMBEDDED_GPU",
+		},
+		{
+			name: "product name sanitizes to empty string",
+			args: args{
+				dev: &pci.Device{
+					Address: "00:1f.6",
+					Vendor: &pcidb.Vendor{
+						ID:   "1234",
+						Name: "Test Vendor",
+					},
+					Product: &pcidb.Product{
+						ID:   "5678",
+						Name: "!!!",
+					},
+				},
+			},
+			want: "test.com/5678",
+		},
+		{
 			name: "AMD Radeon X850",
 			args: args{
 				dev: &pci.Device{


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The [resourceName()](https://github.com/harvester/pcidevices/blob/master/pkg/apis/devices.harvesterhci.io/v1beta1/pcidevice.go#L94) helper could generate invalid Kubernetes extended resource names when PCI product names from the pci.ids database contain trailing spaces inside the bracket notation, which voilates the k8s extended resource naming rules because resource name must end with an alphanumeric character...

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
It trims the trailing separators 

**Related Issue:**
https://github.com/harvester/harvester/issues/10108

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
unit tests added.