### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.25.7
+FROM registry.suse.com/bci/golang:1.26
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH
@@ -29,7 +29,7 @@ RUN export K8S_VERSION=v1.34.0 && \
     tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
 
 ## install golangci
-RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 ENV GO111MODULE=on
 ENV DAPPER_ENV="REPO TAG DRONE_TAG"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/pcidevices
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/NVIDIA/go-nvlib v0.8.0


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
bump golang 1.26

**Solution:**
bump golang 1.26

**Related Issue:**
https://github.com/harvester/harvester/issues/10734

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
