### PR TITLE
task: bump google.golang.org/grpc to v1.79.3 due to CVE-2026-33186

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
-	google.golang.org/grpc v1.72.2
+	google.golang.org/grpc v1.79.3
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/cli-runtime v0.33.1


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Changes:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Bump google.golang.org/grpc to v1.79.3 due to CVE-2026-33186.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Local `make` plus CI/CD. No functional changes.
