### PR TITLE
allow configuring SRIOVGPUDevices in timeslicing mode if the GPU supports both timeslicing / MIG mode

### DIFF
--- a/pkg/apis/devices.harvesterhci.io/v1beta1/sriovgpudevice.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/sriovgpudevice.go
@@ -73,4 +73,6 @@ const (
 	GPUContainerWorkloadKey                          = "harvesterhci.io/gpu-baremetal-workloads"
 	GPUContainerWorkloadValue                        = "true"
 	EnabledSRIOVGPUDevicesByNodeNameIndex            = "harvesterhci.io/enabledSRIOVGPUDevicesByNodeName"
+	SkipMIGConfigurationAnnotationKey                = "harvesterhci.io/skip-mig-configuration"
+	SkipMIGConfigurationAnnotationValue              = "true"
 )

--- a/pkg/controller/gpudevice/gpu_controller.go
+++ b/pkg/controller/gpudevice/gpu_controller.go
@@ -354,6 +354,12 @@ func (h *Handler) reconcileMIGConfiguration(_ string, gpu *v1beta1.SRIOVGPUDevic
 		return gpu, nil
 	}
 
+	val, ok := gpu.Annotations[v1beta1.SkipMIGConfigurationAnnotationKey]
+	if ok && val == v1beta1.SkipMIGConfigurationAnnotationValue {
+		logrus.Debugf("skipping MIG configuration for GPU device %s as annotation is set", gpu.Name)
+		return gpu, nil
+	}
+
 	if gpu.Spec.Enabled {
 		return gpu, h.setupMigConfiguration(gpu)
 	}
@@ -366,6 +372,10 @@ func (h *Handler) reconcileMIGConfiguration(_ string, gpu *v1beta1.SRIOVGPUDevic
 			return gpu, nil
 		}
 		return gpu, err
+	}
+
+	if err := gpuhelper.DisableMIGMode(h.executor, gpu.Spec.Address); err != nil {
+		return gpu, fmt.Errorf("error disabling MIG Mode: %w", err)
 	}
 
 	return gpu, h.migConfigurationController.Delete(gpu.Name, &metav1.DeleteOptions{})

--- a/pkg/util/gpuhelper/mig.go
+++ b/pkg/util/gpuhelper/mig.go
@@ -421,3 +421,18 @@ func generateDeleteGPUInstanceCommand(address, instance string) string {
 func generateEnableMIGModeCommand(address string) string {
 	return fmt.Sprintf("nvidia-smi -i %s -mig 1", address)
 }
+
+// DisableMIGMode will disable MIG mode on the underlying GPU
+func DisableMIGMode(ex executor.Executor, deviceAddress string) error {
+	disableMIGModeCommand := generateDisableMIGModeCommand(deviceAddress)
+	disableMIGModeCommandOutput, err := ex.Run(disableMIGModeCommand, nil)
+	if err != nil {
+		return fmt.Errorf("error executing %s: %w", disableMIGModeCommand, err)
+	}
+	logrus.Debugf("MIG mode disable results for GPU %s: %s", deviceAddress, string(disableMIGModeCommandOutput))
+	return nil
+}
+
+func generateDisableMIGModeCommand(address string) string {
+	return fmt.Sprintf("nvidia-smi -i %s -mig 0", address)
+}

--- a/pkg/webhook/sriovgpudevices.go
+++ b/pkg/webhook/sriovgpudevices.go
@@ -54,7 +54,7 @@ func (v *sriovGPUValidator) Update(_ *types.Request, oldObj runtime.Object, newO
 		return v.checkGPUUsage(newGPUObj)
 	}
 
-	return nil
+	return verifyMIGAnnotation(oldGPUObj, newGPUObj)
 }
 
 func (v *sriovGPUValidator) Delete(_ *types.Request, obj runtime.Object) error {
@@ -85,5 +85,23 @@ func (v *sriovGPUValidator) checkGPUUsage(obj *devicesv1beta1.SRIOVGPUDevice) er
 			return err
 		}
 	}
+	return nil
+}
+
+func verifyMIGAnnotation(obj *devicesv1beta1.SRIOVGPUDevice, newObj *devicesv1beta1.SRIOVGPUDevice) error {
+	// new sriovgpudevice is disabled so no need to verify any annotations
+	// or old sriovgpudevice is disabled so no need to verify any annotations
+	if !newObj.Spec.Enabled || !obj.Spec.Enabled {
+		return nil
+	}
+
+	newVal, newOK := newObj.Annotations[devicesv1beta1.SkipMIGConfigurationAnnotationKey]
+	oldVal, oldOK := obj.Annotations[devicesv1beta1.SkipMIGConfigurationAnnotationKey]
+
+	// block addition/removal of annotation on sriovgpudevice if it is enabled
+	if newOK != oldOK || newVal != oldVal {
+		return fmt.Errorf("cannot add/remove annotation %s on enabled sriovgpudevice %s", devicesv1beta1.SkipMIGConfigurationAnnotationKey, newObj.Name)
+	}
+
 	return nil
 }

--- a/pkg/webhook/sriovgpudevices_test.go
+++ b/pkg/webhook/sriovgpudevices_test.go
@@ -158,3 +158,156 @@ func Test_SriovGPUDelete(t *testing.T) {
 		}
 	}
 }
+
+func Test_verifyMIGAnnotation(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		oldSRIOVGPU *devicesv1beta1.SRIOVGPUDevice
+		newSRIOVGPU *devicesv1beta1.SRIOVGPUDevice
+		expectError bool
+	}{
+		{
+			name: "annotation added to enabled sriovgpudevice",
+			oldSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gpu1",
+					Annotations: map[string]string{},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			newSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+					Annotations: map[string]string{
+						devicesv1beta1.SkipMIGConfigurationAnnotationKey: devicesv1beta1.SkipMIGConfigurationAnnotationValue,
+					},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "annotation removed from enabled sriovgpudevice",
+			oldSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+					Annotations: map[string]string{
+						devicesv1beta1.SkipMIGConfigurationAnnotationKey: devicesv1beta1.SkipMIGConfigurationAnnotationValue,
+					},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			newSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gpu1",
+					Annotations: map[string]string{},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "annotation removed from disabled sriovgpudevice",
+			oldSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+					Annotations: map[string]string{
+						devicesv1beta1.SkipMIGConfigurationAnnotationKey: devicesv1beta1.SkipMIGConfigurationAnnotationValue,
+					},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			newSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gpu1",
+					Annotations: map[string]string{},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  false,
+					NodeName: "node1",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "annotation added to disabled sriovgpudevice",
+			oldSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gpu1",
+					Annotations: map[string]string{},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			newSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+					Annotations: map[string]string{
+						devicesv1beta1.SkipMIGConfigurationAnnotationKey: devicesv1beta1.SkipMIGConfigurationAnnotationValue,
+					},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  false,
+					NodeName: "node1",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "annotation added while enabling sriovgpudevice",
+			oldSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gpu1",
+					Annotations: map[string]string{},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  false,
+					NodeName: "node1",
+				},
+			},
+			newSRIOVGPU: &devicesv1beta1.SRIOVGPUDevice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+					Annotations: map[string]string{
+						devicesv1beta1.SkipMIGConfigurationAnnotationKey: devicesv1beta1.SkipMIGConfigurationAnnotationValue,
+					},
+				},
+				Spec: devicesv1beta1.SRIOVGPUDeviceSpec{
+					Enabled:  true,
+					NodeName: "node1",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := require.New(t)
+			err := verifyMIGAnnotation(tc.oldSRIOVGPU, tc.newSRIOVGPU)
+			if tc.expectError {
+				assert.Error(err, fmt.Sprintf("expected to find error for test case %s", tc.name))
+			} else {
+				assert.NoError(err, fmt.Sprintf("expected to find no errorerror for test case %s", tc.name))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
With Harvester v1.7.x we introduced support for MIG backed vGPUs.

Most MIG mode GPU's also support timeslicing mode.

Some users may wish to continue using the GPU in timeslicing mode for vGPUs. This is currently not possible as the pcidevices controller identifies if GPU supports MIG mode and defaults to using vGPU backed by MIG profiles.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR allows users to annotation SRIOVGPUDevices with a specific key/value to allow vGPUs to be used in timesliced vGPU profiles.

```
harvesterhci.io/skip-mig-configuration: "true"
```

**Related Issue:**
https://github.com/harvester/harvester/issues/11133

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
