### PR TITLE
change node.Status.GPUAddresses field to mandatory to ensure successful reconcile

### DIFF
--- a/pkg/apis/devices.harvesterhci.io/v1beta1/node.go
+++ b/pkg/apis/devices.harvesterhci.io/v1beta1/node.go
@@ -23,7 +23,7 @@ type NodeStatus struct {
 	// GPUAddresses is used to track NVIDIA GPU addresses on the node
 	// this can be used by validator to block pcidevice claims for addresses if node is
 	// setup to be used for baremetal gpu container workloads
-	GPUAddresses []string `json:"gpuAddresses,omitempty"`
+	GPUAddresses []string `json:"gpuAddresses"`
 }
 
 const (

--- a/pkg/util/gousb/usbid/load_data.go
+++ b/pkg/util/gousb/usbid/load_data.go
@@ -27,8 +27,8 @@ import "time"
 //
 // The baked-in data was last generated:
 //
-// 2026-07-22 05:39:21.132900893 +0000 UTC m=+3.319843655
-var LastUpdate = time.Unix(0, 1784698761132900893)
+// 2026-08-07 00:49:29.579892562 +0000 UTC m=+1.721887049
+var LastUpdate = time.Unix(0, 1786063769579892562)
 
 const usbIDListData = `#
 #	List of USB ID's


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PCIDevices reconcile is broken on new install due to the PR https://github.com/harvester/pcidevices/pull/296

PR changes the `node.devices` object to make `GPUAddresses` a mandatory field in `status`.

Currently when `[]GPUAddresses` are empty, since field is optional, nothing is set in status field of object.

DeepEqual always finds `nil` and `[]string` do not match so keeps triggering an update which results in node reconcile never moving on to subsequent device reconcile.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
https://github.com/harvester/harvester/issues/11360

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Install harvester master-head or v1.9-head to a new cluster
* Enable PCIDevices controller on a node without GPUs
* Wait for a few mins, and PCIDevices should be populated