### PR TITLE
pcidevice controller: use stdlib slices

### DIFF
--- a/pkg/controller/pcidevice/pcidevice_controller.go
+++ b/pkg/controller/pcidevice/pcidevice_controller.go
@@ -2,6 +2,7 @@ package pcidevice
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	ctlnetworkv1beta1 "github.com/harvester/harvester-network-controller/pkg/generated/controllers/network.harvesterhci.io/v1beta1"
@@ -54,7 +55,7 @@ func (h *Handler) ReconcilePCIDevices(nodename string) error {
 	commonLabels := map[string]string{"nodename": nodename} // label
 	var setOfRealPCIAddrs = make(map[string]bool)
 	for _, dev := range h.pci.Devices {
-		if !containsString(h.skipAddresses, dev.Address) {
+		if !slices.Contains(h.skipAddresses, dev.Address) {
 			setOfRealPCIAddrs[dev.Address] = true
 			name := v1beta1.PCIDeviceNameForHostname(dev.Address, nodename)
 			// Check if device is stored
@@ -136,16 +137,6 @@ func (h *Handler) ReconcilePCIDevices(nodename string) error {
 	}
 
 	return nil
-}
-
-func containsString(elements []string, element string) bool {
-	for _, v := range elements {
-		if v == element {
-			return true
-		}
-	}
-
-	return false
 }
 
 // IdentifyPCIBridgeDevices will identify devices which are pci bridges to skip the same


### PR DESCRIPTION
Replace custom search function with `slices.Contains` from the Golang stdlib.

**Problem:**

Use of (untested) custom function for something that the stdlib provides.

**Solution:**

Use stdlib.

**Related Issue:**

**Test plan:**

N/A.
Unit tests cover this section of code. No functional changes are expected.
